### PR TITLE
fix: client fixes, tweaks and examples

### DIFF
--- a/client/examples/multiple.html
+++ b/client/examples/multiple.html
@@ -9,7 +9,7 @@
 </form>
 <pre id="out"></pre>
 <script type="module">
-  import NFTStore from '../src/lib.js'
+  import NFTStore from 'https://unpkg.com/nft.storage?module'
 
   const endpoint = 'https://nft.storage' // the default
   const token = 'API_KEY' // your API key from https://nft.storage/manage

--- a/client/examples/multiple.html
+++ b/client/examples/multiple.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<form>
+  <label>
+    File(s): <input type="file" multiple />
+  </label>
+  <div>
+    <button type="submit">Store</button>
+  </div>
+</form>
+<pre id="out"></pre>
+<script type="module">
+  import NFTStore from '../src/lib.js'
+
+  const endpoint = 'https://nft.storage' // the default
+  const token = 'API_KEY' // your API key from https://nft.storage/manage
+
+  function log (msg) {
+    document.getElementById('out').innerHTML += `${JSON.stringify(msg, null, 2)}\n`
+  }
+
+  document.querySelector('form').addEventListener('submit', async e => {
+    e.preventDefault()
+    const fileEl = document.querySelector('input[type="file"]')
+    if (!fileEl.files.length) return log('No files selected')
+    log(`Storing ${fileEl.files.length} files...`)
+    const store = new NFTStore({ endpoint, token })
+    const cid = await store.storeDirectory(fileEl.files)
+    log({ files: Array.from(fileEl.files).map(f => f.name), cid })
+    const status = await store.status(cid)
+    log(status)
+  })
+</script>

--- a/client/examples/single.html
+++ b/client/examples/single.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<pre id="out"></pre>
+<script type="module">
+  import NFTStore from '../src/lib.js'
+
+  const endpoint = 'https://nft.storage' // the default
+  const token = 'API_KEY' // your API key from https://nft.storage/manage
+
+  function log (msg) {
+    document.getElementById('out').innerHTML += `${JSON.stringify(msg, null, 2)}\n`
+  }
+
+  async function main () {
+    const store = new NFTStore({ endpoint, token })
+    const data = 'Hello nft.storage!'
+    const cid = await store.storeBlob(new Blob([data]))
+    log({ data, cid })
+    const status = await store.status(cid)
+    log(status)
+  }
+  main()
+</script>

--- a/client/examples/single.html
+++ b/client/examples/single.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <pre id="out"></pre>
 <script type="module">
-  import NFTStore from '../src/lib.js'
+  import NFTStore from 'https://unpkg.com/nft.storage?module'
 
   const endpoint = 'https://nft.storage' // the default
   const token = 'API_KEY' // your API key from https://nft.storage/manage

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -1,5 +1,3 @@
-import type { CID } from "multiformats"
-
 export interface Service {
   endpoint: URL
   token: string
@@ -9,31 +7,31 @@ export interface API {
   /**
    * Stores a single file and returns a corresponding CID.
    */
-  storeBlob(service: Service, content: Blob|File): Promise<CID>
+  storeBlob(service: Service, content: Blob|File): Promise<string>
   /**
    * Stores a directory of files and returns a CID. Provided files **MUST**
    * be within a same directory, otherwise error is raised. E.g. `foo/bar.png`,
    * `foo/bla/baz.json` is ok but `foo/bar.png`, `bla/baz.json` is not.
    */
-  storeDirectory(service: Service, files: Iterable<File>): Promise<CID>
+  storeDirectory(service: Service, files: Iterable<File>): Promise<string>
   /**
    * Returns current status of the stored content by its CID.
    */
-  status(service: Service, cid: CID): Promise<StatusResult>
+  status(service: Service, cid: string): Promise<StatusResult>
   /**
    * Removes stored content by its CID from the service. Please note that
    * even if content is removed from the service other nodes that have
    * replicated it might still continue providing it.
    */
-  delete(service: Service, cid: CID): Promise<void>
+  delete(service: Service, cid: string): Promise<void>
 }
 
 export interface StatusResult {
-  cid: CID
+  cid: string
   size: number,
   deals: Deals,
   pin: Pin
-  created: string
+  created: Date
 }
 
 export type Deals = OngoingDeals | FinalizedDeals
@@ -98,7 +96,7 @@ export interface FinalizedDeal {
 export interface Pin {
   // Pinata does not provide this
   // requestid: string
-  cid: CID
+  cid: string
   name?: string
   status: PinStatus
   created: Date

--- a/client/src/lib.js
+++ b/client/src/lib.js
@@ -1,15 +1,9 @@
 import * as API from "./api.js"
-import CID from "multiformats/cid"
-
-
 
 /**
  * @implements {API.Service}
  */
 export default class NFTStore {
-  static get CID() {
-    return CID
-  }
   /**
    * @param {Object} options
    * @param {string} options.token
@@ -42,7 +36,7 @@ export default class NFTStore {
     const result = await request.json()
 
     if (result.ok) {
-      return CID.parse(result.value.cid)
+      return result.value.cid
     } else {
       throw new Error(result.error)
     }
@@ -66,7 +60,7 @@ export default class NFTStore {
     const result = await response.json()
 
     if (result.ok) {
-      return CID.parse(result.value.cid)
+      return result.value.cid
     } else {
       throw new Error(result.error)
     }
@@ -74,11 +68,11 @@ export default class NFTStore {
 
   /**
    * @param {API.Service} service
-   * @param {CID} cid
+   * @param {string} cid
    * @returns {Promise<API.StatusResult>}
    */
   static async status({ endpoint, token }, cid) {
-    const url = new URL(`/api/status/${cid}`, endpoint)
+    const url = new URL(`/api/${cid}`, endpoint)
     const response = await fetch(url.toString(), {
       method: "GET",
       headers: NFTStore.auth(token),
@@ -87,12 +81,10 @@ export default class NFTStore {
     
     if (result.ok) {
       return {
-        cid: CID.parse(result.value.cid),
+        cid: result.value.cid,
         deals: result.value.deals,
-        pin: {
-          ...result.value.pin,
-          cid: CID.parse(result.value.pin.cid),
-        },
+        size: result.value.size,
+        pin: result.value.pin,
         created: new Date(result.value.created),
       }
     } else {
@@ -102,11 +94,11 @@ export default class NFTStore {
 
   /**
    * @param {API.Service} service
-   * @param {CID} cid
+   * @param {string} cid
    * @returns {Promise<void>}
    */
   static async delete({ endpoint, token }, cid) {
-    const url = new URL(`/api/delete/${cid}`, endpoint)
+    const url = new URL(`/api/${cid}`, endpoint)
     const response = await fetch(url.toString(), {
       method: "DELETE",
       headers: NFTStore.auth(token),
@@ -132,13 +124,13 @@ export default class NFTStore {
     return NFTStore.storeDirectory(this, files)
   }
   /**
-   * @param {CID} cid
+   * @param {string} cid
    */
   status(cid) {
     return NFTStore.status(this, cid)
   }
   /**
-   * @param {CID} cid
+   * @param {string} cid
    */
   delete(cid) {
     return NFTStore.delete(this, cid)

--- a/client/test/lib.spec.js
+++ b/client/test/lib.spec.js
@@ -25,7 +25,7 @@ test('client', ({test}) => {
     test('upload blob', async assert => {
       const client = new NFTStorage({ token, endpoint })
       const cid = await client.storeBlob(new Blob(['hello world']))
-      assert.equal(cid.toString(), 'Qmf412jQZiuVUtdgnB36FXFX7xg5V6KEbSJ4dpQuhkLyfD')
+      assert.equal(cid, 'Qmf412jQZiuVUtdgnB36FXFX7xg5V6KEbSJ4dpQuhkLyfD')
     })
 
     test('can upload twice', async assert => {
@@ -60,13 +60,13 @@ test('client', ({test}) => {
     })
 
     test('found', async assert => {
-      const cid = NFTStorage.CID.parse('QmaCxv35MgHdAD2K9Tn8xrKVZJw7dauYi4V1GmkQRNYbvP')
+      const cid = 'QmaCxv35MgHdAD2K9Tn8xrKVZJw7dauYi4V1GmkQRNYbvP'
       const status = await client.status(cid)
       assert.deepEqual(status.cid, cid)
     })
 
     test('not found', async assert => {
-      const cid = NFTStorage.CID.parse('QmTPFUEcZvqKBYqJM3itqkDiqJaApYzLJ1ht6iBD4d6M28')
+      const cid = 'QmTPFUEcZvqKBYqJM3itqkDiqJaApYzLJ1ht6iBD4d6M28'
       try {
         await client.status(cid)
         assert.fail('Expected to fail')
@@ -79,7 +79,7 @@ test('client', ({test}) => {
   test('delete', ({test}) => {
     test('ok to delete unknown', async assert => {
       const client = new NFTStorage({ token, endpoint })
-      const cid = NFTStorage.CID.parse('Qmf412jQZiuVUtdgnB36FXFX7xg5V6KEbSJ4dpQuhkLyfD')
+      const cid = 'Qmf412jQZiuVUtdgnB36FXFX7xg5V6KEbSJ4dpQuhkLyfD'
       const result = await client.delete(cid)
       assert.equal(result, undefined)
     })

--- a/client/test/run.js
+++ b/client/test/run.js
@@ -22,7 +22,7 @@ const main = async () => {
 
   const service = await activate(async (request) => {
     const url = new URL(request.url)
-    const [_, api, endpoint, param] = url.pathname.split('/')
+    const [_, api, param] = url.pathname.split('/')
     const auth = request.headers.get('authorization')
     const [, token] = (auth && auth.match(/Bearer (.+)/)) || []
 
@@ -44,7 +44,7 @@ const main = async () => {
       })
     }
 
-    switch (`${request.method} /${api}/${endpoint}`) {
+    switch (`${request.method} /${api}/${param}`) {
       case 'POST /api/upload': {
         const contentType = request.headers.get('content-type') || ''
         if (contentType.includes('multipart/form-data')) {
@@ -72,7 +72,7 @@ const main = async () => {
           })
         }
       }
-      case 'GET /api/status': {
+      case `GET /api/${param}`: {
         const cid = CID.parse(param || '')
         const value = store.get(`${token}:${cid}`)
         const [status, result] = value
@@ -84,7 +84,7 @@ const main = async () => {
           headers: headers(request)
         })
       }
-      case 'DELETE /api/delete': {
+      case `DELETE /api/${param}`: {
         const cid = CID.parse(param || '')
         store.delete(`${token}:${cid}`)
         return new Response(JSON.stringify({ ok: true }), {


### PR DESCRIPTION
* Fixes the status and delete endpoint URLs
* Removes the CID dependency, as it currently doesn't work with multiformats/cid on unpkg (https://unpkg.com/multiformats@4.5.3/cid?module)
* Adds a couple of examples for storing files and querying their status