### PR TITLE
feat: store metadata in IPLD CBOR format

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -33,6 +33,7 @@
     "prepare": "npm run build"
   },
   "dependencies": {
+    "@ipld/dag-cbor": "^4.0.0",
     "@web-std/blob": "2.0.1",
     "@web-std/fetch": "1.0.0",
     "@web-std/file": "1.0.1",
@@ -40,20 +41,20 @@
   },
   "devDependencies": {
     "@ssttevee/multipart-parser": "0.1.8",
-    "uvu": "0.5.1",
-    "mocha": "8.3.2",
     "@types/mocha": "8.2.1",
     "ipfs-unixfs-importer": "6.0.1",
     "ipld": "0.29.0",
     "ipld-dag-pb": "0.22.0",
     "ipld-in-memory": "8.0.0",
+    "mocha": "8.3.2",
     "multicodec": "3.0.1",
-    "multiformats": "4.5.3",
+    "multiformats": "^4.5.3",
     "multihashing-async": "2.1.2",
     "playwright-test": "2.1.0",
-    "typedoc": "0.20.32",
     "rollup": "2.22.1",
-    "rollup-plugin-multi-input": "1.1.1"
+    "rollup-plugin-multi-input": "1.1.1",
+    "typedoc": "0.20.32",
+    "uvu": "0.5.1"
   },
   "homepage": "https://github.com/ipfs-shipyard/nft.storage/tree/main/client",
   "bugs": "https://github.com/ipfs-shipyard/nft.storage/issues"


### PR DESCRIPTION
This PR adds a `storeMetadata` method that allows for storing NFT metadata encoded using IPLD CBOR.

It takes an `Object` - the metadata to persist. It recursively inspects the object to see if there are any `File`s or `Blob`s and when it find them it calls `storeBlob`/`storeDirectory` and replaces them with a CID.

The result is an object that we can pass to `js-dag-cbor` for encoding.

I need to figure out how to store the encoded data. I've just passed it to `storeBlob`, which gives us back a CID with the RAW codec (since it's small enough and we specify v1 CIDs, giving us raw leaves). In the code I'm taking this RAW CID and re-encoding it to be CBOR. I thought this would work but it looks like the blockstore is still keyed on CID not multihash...

The plan was to then be able to view this on the gateway: https://github.com/ipfs/go-ipfs/pull/8037

I'm using this code to test (runnable in Node.js):

```js
import fs from 'fs'
import { NFTStorage, File } from '../../src/lib.js'

const endpoint = 'https://staging.nft.storage'
const token = 'xxx'

async function main() {
  const store = new NFTStorage({ endpoint, token })
  const data = await fs.promises.readFile('lost-dog.jpg')
  const cid = await store.storeMetadata({
    name: 'My NFT',
    image: new File([data], 'lost-dog.jpg')
  })
  console.log({ cid })
}
main()

```