### PR TITLE
fix: error message for deleted token

### DIFF
--- a/site/src/utils/utils.js
+++ b/site/src/utils/utils.js
@@ -144,7 +144,10 @@ export async function verifyToken(event, mode = 'both') {
       if (typeof tokenName === 'string') {
         return { ok: true, user, tokenName }
       } else {
-        return { ok: false, error: new HTTPError('Session expired', 403) }
+        return {
+          ok: false,
+          error: new HTTPError('Expired or deleted token', 403),
+        }
       }
     } else {
       return { ok: false, error: new HTTPError('Token is not valid', 403) }


### PR DESCRIPTION
If you use a token that has been deleted then you'll get a "Session expired" message. There are no "sessions" with tokens so this is misleading.

fixes #48