### PR TITLE
feat: cron jobs for metrics and pin status tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ wrangler kv:namespace create NFTS --preview --env USER
 # same as above
 wrangler kv:namespace create DEALS --preview --env USER
 # same as above
+wrangler kv:namespace create METRICS --preview --env USER
+# same as above
 ```
 
 Go to `/site/src/constants.js` _uncomment_ the first line and run `wrangler publish --env USER`.
@@ -149,6 +151,8 @@ wrangler kv:namespace create CSRF --env production
 wrangler kv:namespace create NFTS --env production
 # Follow the instructions from the cli output
 wrangler kv:namespace create DEALS --env production
+# Follow the instructions from the cli output
+wrangler kv:namespace create METRICS --env production
 # Follow the instructions from the cli output
 wrangler secret put AUTH0_DOMAIN --env production # Get from auth0 account
 wrangler secret put AUTH0_CLIENT_ID --env production # Get from auth0 account

--- a/site/src/bindings.d.ts
+++ b/site/src/bindings.d.ts
@@ -12,6 +12,7 @@ declare global {
   const DEALS: KVNamespace
   const USERS: KVNamespace
   const NFTS: KVNamespace
+  const METRICS: KVNamespace
   const PINATA_JWT: string
   const CLUSTER_API_URL: string
   const CLUSTER_BASIC_AUTH_TOKEN: string

--- a/site/src/cluster.js
+++ b/site/src/cluster.js
@@ -69,6 +69,7 @@ export async function dagSize(cid) {
     cluster.ipfsProxyApiUrl
   )
   const response = await fetch(url.toString(), {
+    method: 'POST',
     headers: { Authorization: `Basic ${cluster.ipfsProxyBasicAuthToken}` },
   })
   if (!response.ok) {

--- a/site/src/constants.js
+++ b/site/src/constants.js
@@ -5,6 +5,7 @@ export const stores = {
   deals: DEALS,
   users: USERS,
   nfts: NFTS,
+  metrics: METRICS,
 }
 
 export const auth0 = {

--- a/site/src/index.js
+++ b/site/src/index.js
@@ -45,6 +45,14 @@ r.add('get', '/new-key', newKey)
 r.add('get', '/new-file', newFile)
 // Monitoring
 r.add('get', '/metrics', metrics)
+// Cron testing
+// r.add('get', '/cron', async event => {
+//   await timed(updateUserMetrics, 'updateUserMetrics')
+//   await timed(updateNftMetrics, 'updateNftMetrics')
+//   await timed(updateNftDealMetrics, 'updateNftDealMetrics')
+//   await timed(updatePinStatuses, 'updatePinStatuses')
+//   return new Response('done')
+// })
 
 r.add('options', '/api/*', cors)
 // Remote Pinning API

--- a/site/src/index.js
+++ b/site/src/index.js
@@ -45,14 +45,6 @@ r.add('get', '/new-key', newKey)
 r.add('get', '/new-file', newFile)
 // Monitoring
 r.add('get', '/metrics', metrics)
-// Cron testing
-// r.add('get', '/cron', async event => {
-//   await timed(updateUserMetrics, 'updateUserMetrics')
-//   await timed(updateNftMetrics, 'updateNftMetrics')
-//   await timed(updateNftDealMetrics, 'updateNftDealMetrics')
-//   await timed(updatePinStatuses, 'updatePinStatuses')
-//   return new Response('done')
-// })
 
 r.add('options', '/api/*', cors)
 // Remote Pinning API

--- a/site/src/jobs/metrics.js
+++ b/site/src/jobs/metrics.js
@@ -1,0 +1,148 @@
+import { stores } from '../constants.js'
+import * as metrics from '../models/metrics.js'
+import * as deals from '../models/deals.js'
+
+/**
+ * @typedef {{
+ *   queued: number,
+ *   proposing: number,
+ *   accepted: number,
+ *   failed: number,
+ *   published: number,
+ *   active: number,
+ *   terminated: number
+ * }} DealsSummary
+ */
+
+// TODO: keep running total?
+export async function updateUserMetrics() {
+  let total = 0
+  let done = false
+  let cursor
+  while (!done) {
+    // @ts-ignore
+    const users = await stores.users.list({ cursor })
+    total += users.keys.length
+    cursor = users.cursor
+    done = users.list_complete
+  }
+  await metrics.set('users:total', total)
+}
+
+// TODO: keep running totals?
+export async function updateNftMetrics() {
+  let total = 0
+  let totalBytes = 0
+  let totalPins = 0
+  let done = false
+  let cursor
+  while (!done) {
+    // @ts-ignore
+    const nftList = await stores.nfts.list({ cursor, limit: 1000 })
+    total += nftList.keys.length
+    for (const k of nftList.keys) {
+      if (!k.metadata) continue
+      totalBytes += k.metadata.size || 0
+      if (k.metadata.pinStatus === 'pinned') {
+        totalPins++
+      }
+    }
+    cursor = nftList.cursor
+    done = nftList.list_complete
+  }
+  await Promise.all([
+    // Total number of NFTs stored on nft.storage
+    metrics.set('nfts:total', total),
+    // Total bytes of all NFTs
+    metrics.set('nfts:totalBytes', totalBytes),
+    // Total number of NFTs pinned on IPFS
+    metrics.set('nfts:pins:total', totalPins),
+  ])
+}
+
+// TODO: keep running totals?
+export async function updateNftDealMetrics() {
+  const totals = {
+    queued: 0,
+    proposing: 0,
+    accepted: 0,
+    failed: 0,
+    published: 0,
+    active: 0,
+    terminated: 0,
+    unknown: 0,
+  }
+  let done = false
+  let cursor
+  while (!done) {
+    // @ts-ignore
+    const dealList = await stores.deals.list({ cursor, limit: 1000 })
+    for (const k of dealList.keys) {
+      /** @type {DealsSummary} */
+      let summary = k.metadata
+      // TODO: remove when ALL deals have summary in metadata
+      if (summary == null) {
+        const d = await deals.get(k.name)
+        if (!d.length) continue
+        summary = getDealsSummary(d)
+      }
+      const status = getEffectiveStatus(summary)
+      totals[status]++
+    }
+    cursor = dealList.cursor
+    done = dealList.list_complete
+  }
+  await Promise.all([
+    // Total number of NFTs stored on Filecoin in active deals
+    metrics.set('nfts:deals:active:total', totals.active),
+    metrics.set('nfts:deals:published:total', totals.published),
+    metrics.set('nfts:deals:accepted:total', totals.accepted),
+    metrics.set('nfts:deals:proposing:total', totals.proposing),
+    // Total number of NFTs queued for the next deal batch
+    metrics.set('nfts:deals:queued:total', totals.queued),
+    metrics.set('nfts:deals:failed:total', totals.failed),
+    metrics.set('nfts:deals:terminated:total', totals.terminated),
+  ])
+}
+
+/**
+ * @param {import('../bindings.js').Deal[]} deals
+ * @returns {DealsSummary}
+ */
+function getDealsSummary(deals) {
+  const summary = {
+    queued: 0,
+    proposing: 0,
+    accepted: 0,
+    failed: 0,
+    published: 0,
+    active: 0,
+    terminated: 0,
+  }
+  deals.forEach((d) => {
+    summary[d.status]++
+  })
+  return summary
+}
+
+/**
+ *
+ * @param {DealsSummary} summary
+ * @returns {import('../bindings.js').Deal['status'] | 'unknown'}
+ */
+function getEffectiveStatus(summary) {
+  /** @type import('../bindings.js').Deal['status'][] */
+  const orderedStatues = [
+    'active',
+    'published',
+    'accepted',
+    'proposing',
+    'queued',
+    'failed',
+    'terminated',
+  ]
+  for (const s of orderedStatues) {
+    if (summary[s]) return s
+  }
+  return 'unknown'
+}

--- a/site/src/jobs/pins.js
+++ b/site/src/jobs/pins.js
@@ -1,0 +1,49 @@
+import { stores } from '../constants.js'
+import * as cluster from '../cluster.js'
+
+export async function updatePinStatuses() {
+  let done = false
+  let cursor
+  while (!done) {
+    // @ts-ignore
+    const nftList = await stores.nfts.list({ cursor, limit: 1000 })
+    for (const k of nftList.keys) {
+      const cid = k.name.split(':')[1]
+      // Look up size for pinned data via pinning service API
+      if (k.metadata == null || !isPinnedOrFailed(k.metadata.pinStatus)) {
+        try {
+          const pinStatus = cluster.toPSAStatus(await cluster.status(cid))
+          if (!isPinnedOrFailed(pinStatus)) continue
+          const d = await stores.nfts.getWithMetadata(k.name)
+          if (d.value == null) throw new Error('missing NFT')
+          /** @type import('../bindings').NFT */
+          const nft = JSON.parse(d.value)
+          const prevStatus = nft.pin.status
+          nft.pin.status = pinStatus
+          const prevSize = nft.size
+          if (pinStatus === 'pinned') {
+            // for successful pin we can update the size
+            nft.size = nft.pin.size = nft.size || (await cluster.dagSize(cid))
+          }
+          // @ts-ignore
+          const metadata = { ...(d.metadata || {}), pinStatus, size: nft.size }
+          await stores.nfts.put(k.name, JSON.stringify(nft), { metadata })
+          console.log(
+            `${cid}: pin status ${prevStatus} => ${nft.pin.status}, size ${prevSize} => ${nft.size}`
+          )
+        } catch (err) {
+          console.error(`${cid}: failed to update pin status and size`, err)
+        }
+      }
+    }
+    cursor = nftList.cursor
+    done = nftList.list_complete
+  }
+}
+
+/**
+ * @param {string} status
+ */
+function isPinnedOrFailed(status) {
+  return ['pinned', 'failed'].includes(status)
+}

--- a/site/src/jobs/pins.js
+++ b/site/src/jobs/pins.js
@@ -32,7 +32,9 @@ export async function updatePinStatuses() {
             `${cid}: pin status ${prevStatus} => ${nft.pin.status}, size ${prevSize} => ${nft.size}`
           )
         } catch (err) {
-          console.error(`${cid}: failed to update pin status and size`, err)
+          console.error(
+            `${cid}: failed to update pin status and size: ${err.stack}`
+          )
         }
       }
     }

--- a/site/src/models/metrics.js
+++ b/site/src/models/metrics.js
@@ -1,0 +1,18 @@
+import { stores as metrics } from '../constants.js'
+
+/**
+ * @param {string} key
+ * @returns {Promise<any>}
+ */
+export async function get(key) {
+  return metrics.metrics.get(key, 'json')
+}
+
+/**
+ * @param {string} key
+ * @param {any} value
+ * @returns {Promise<void>}
+ */
+export const set = async (key, value) => {
+  await metrics.metrics.put(key, JSON.stringify(value))
+}

--- a/site/src/routes/metrics.js
+++ b/site/src/routes/metrics.js
@@ -1,201 +1,42 @@
-import { stores } from '../constants.js'
-import * as Pinata from '../pinata.js'
-
-const MAX_AGE_SECS = 600 // max age of a metrics response in seconds
-const STALE_WHILE_REVALIDATE_SECS = 3600
-
-/**
- * Note: add a cache busting suffix if you change the code and want to see a
- * change immediately after deploy.
- * @param {string} url
- * @returns {string}
- */
-function getCacheKey(url) {
-  return `${new URL(url).origin}/metrics?v=4`
-}
+import { get } from '../models/metrics.js'
 
 /**
  * TODO: basic auth
- * @param {FetchEvent} event
  */
-export async function metrics(event) {
-  const cache = caches.default
-  const cacheKey = getCacheKey(event.request.url)
-
-  let res = await cache.match(cacheKey)
-  if (res) return res
-
-  const [userMetrics, nftMetrics] = await Promise.all([
-    getUserMetrics(),
-    getNftMetrics(),
-  ])
-  res = new Response(exportPromMetrics({ userMetrics, nftMetrics }))
-  // Cache the response for MAX_AGE_SECS
-  res.headers.append(
-    'Cache-Control',
-    `public,max-age=${MAX_AGE_SECS},stale-while-revalidate=${STALE_WHILE_REVALIDATE_SECS}`
-  )
-  event.waitUntil(cache.put(cacheKey, res.clone()))
-  return res
-}
-
-// TODO: keep running total?
-async function getUserMetrics() {
-  let total = 0
-  let done = false
-  let cursor
-  while (!done) {
-    // @ts-ignore
-    const users = await stores.users.list({ cursor })
-    total += users.keys.length
-    cursor = users.cursor
-    done = users.list_complete
-  }
-  return { total }
-}
-
-class DealTotals {
-  constructor() {
-    this.proposing = { total: 0 }
-    this.accepted = { total: 0 }
-    this.failed = { total: 0 }
-    this.published = { total: 0 }
-    this.active = { total: 0 }
-    this.terminated = { total: 0 }
-  }
-}
-
-class NftMetrics {
-  constructor() {
-    this.total = 0 // Total number of NFTs stored on nft.storage
-    this.totalBytes = 0 // Total bytes of all NFTs
-    this.storage = {
-      ipfs: {
-        total: 0, // Total number of NFTs pinned on IPFS
-      },
-      filecoin: {
-        total: 0, // Total number of NFTs stored on Filecoin in active deals
-        totalQueued: 0, // Total number of NFTs queued for the next deal batch
-        deals: {
-          mainnet: new DealTotals(),
-          nerpanet: new DealTotals(),
-        },
-      },
-    }
-  }
-}
-
-// TODO: keep running totals?
-async function getNftMetrics() {
-  const metrics = new NftMetrics()
-  const seenDeals = new Set()
-  let done = false
-  let cursor
-  while (!done) {
-    // @ts-ignore
-    const nftList = await stores.nfts.list({ cursor, limit: 1000 })
-    metrics.total += nftList.keys.length
-    /** @type Array<{ cid: string, pinStatus: string, size: number, deals: any[] }> */
-    const nftMetas = []
-    for (const k of nftList.keys) {
-      const cid = k.name.split(':')[1]
-      // Look up size for pinned data via pinning service API
-      // TODO: move this to cron job
-      if (k.metadata == null || k.metadata.pinStatus !== 'pinned') {
-        try {
-          const res = await Pinata.pinInfo(cid)
-          if (!res.ok) throw new Error('pinata file info request error')
-          if (!res.value) continue // TODO: stop checking after some time and mark as failed
-          const d = await stores.nfts.get(k.name)
-          if (d == null) continue
-          const nft = JSON.parse(d)
-          nft.size = res.value.size
-          await stores.nfts.put(k.name, JSON.stringify(nft), {
-            metadata: { pinStatus: 'pinned', size: nft.size },
-          })
-          nftMetas.push({
-            cid,
-            pinStatus: nft.pin.status,
-            size: nft.size,
-            deals: [],
-          })
-        } catch (err) {
-          console.error(`failed to update file size for ${cid}`, err)
-        }
-        continue
-      }
-      nftMetas.push({ cid, deals: [], ...k.metadata })
-    }
-
-    for (const meta of nftMetas) {
-      metrics.totalBytes += meta.size || 0
-      if (meta.pinStatus === 'pinned') {
-        metrics.storage.ipfs.total++
-      }
-      for (const d of meta.deals) {
-        const ntwk = d.network || 'unknown'
-        // TODO: @riba will add a "key" to deals that is essentially this - switch to using it
-        const key = `${ntwk}/${d.miner}/${d.batchRootCid}`
-        if (seenDeals.has(key)) continue
-        seenDeals.add(key)
-        if (d.status === 'queued') {
-          metrics.storage.filecoin.totalQueued++
-        } else {
-          // @ts-ignore
-          let dealTotals = metrics.storage.filecoin.deals[ntwk]
-          if (dealTotals == null) {
-            // @ts-ignore
-            dealTotals = metrics.storage.filecoin.deals[ntwk] = new DealTotals()
-          }
-          dealTotals[d.status] = dealTotals[d.status] || { total: 0 }
-          dealTotals[d.status].total++
-        }
-      }
-    }
-    cursor = nftList.cursor
-    done = nftList.list_complete
-  }
-  metrics.storage.filecoin.total = Object.values(
-    metrics.storage.filecoin.deals
-  ).reduce((total, dealTotals) => total + dealTotals.active.total, 0)
-  return metrics
+export async function metrics() {
+  return new Response(await exportPromMetrics())
 }
 
 /**
  * Exports metrics in prometheus exposition format.
  * https://prometheus.io/docs/instrumenting/exposition_formats/
- * @param {{ userMetrics: { total: number }, nftMetrics: NftMetrics }} metrics
- * @returns {string}
+ * @returns {Promise<string>}
  */
-function exportPromMetrics({ userMetrics, nftMetrics }) {
+async function exportPromMetrics() {
+  /** @type {(k: string) => Promise<number>} */
+  const getOr0 = async (k) => (await get(k)) || 0
   return [
     '# HELP nftstorage_users_total Total users registered.',
     '# TYPE nftstorage_users_total counter',
-    `nftstorage_users_total ${userMetrics.total}`,
+    `nftstorage_users_total ${await getOr0('users:total')}`,
     '# HELP nftstorage_nfts_total Total number of NFTs stored.',
     '# TYPE nftstorage_nfts_total counter',
-    `nftstorage_nfts_total ${nftMetrics.total}`,
+    `nftstorage_nfts_total ${await getOr0('nfts:total')}`,
     '# HELP nftstorage_nfts_bytes_total Total bytes of all NFTs.',
     '# TYPE nftstorage_nftstorage_nfts_bytes_total counter',
-    `nftstorage_nfts_bytes_total ${nftMetrics.totalBytes}`,
+    `nftstorage_nfts_bytes_total ${await getOr0('nfts:totalBytes')}`,
     '# HELP nftstorage_nfts_storage_ipfs_total Total number of NFTs pinned on IPFS.',
     '# TYPE nftstorage_nfts_storage_ipfs_total counter',
-    `nftstorage_nfts_storage_ipfs_total ${nftMetrics.storage.ipfs.total}`,
+    `nftstorage_nfts_storage_ipfs_total ${await getOr0('nfts:pins:total')}`,
     '# HELP nftstorage_nfts_storage_filecoin_total Total number of NFTs stored on Filecoin in active deals.',
     '# TYPE nftstorage_nfts_storage_filecoin_total counter',
-    `nftstorage_nfts_storage_filecoin_total ${nftMetrics.storage.filecoin.total}`,
+    `nftstorage_nfts_storage_filecoin_total ${await getOr0(
+      'nfts:deals:active:total'
+    )}`,
     '# HELP nftstorage_nfts_storage_filecoin_queued_total Total number of NFTs queued for the next deal batch.',
     '# TYPE nftstorage_nfts_storage_filecoin_queued_total counter',
-    `nftstorage_nfts_storage_filecoin_queued_total ${nftMetrics.storage.filecoin.totalQueued}`,
-    ...Object.entries(nftMetrics.storage.filecoin.deals).map(([ntwk, totals]) =>
-      [
-        `# HELP nftstorage_nfts_storage_filecoin_deals_${ntwk}_total Total number of NFTs participating in Filecoin deals for ${ntwk}.`,
-        `# TYPE nftstorage_nfts_storage_filecoin_deals_${ntwk}_total counter`,
-        ...Object.entries(totals).map(
-          ([status, { total }]) =>
-            `nftstorage_nfts_storage_filecoin_deals_${ntwk}_total{status="${status}"} ${total}`
-        ),
-      ].join('\n')
-    ),
+    `nftstorage_nfts_storage_filecoin_queued_total ${await getOr0(
+      'nfts:deals:queued:total'
+    )}`,
   ].join('\n')
 }

--- a/site/src/utils/utils.js
+++ b/site/src/utils/utils.js
@@ -171,3 +171,20 @@ export async function verifyToken(event, mode = 'both') {
 
   return { ok: false, error: new HTTPError('Unauthorized', 401) }
 }
+
+/**
+ * @template T
+ * @param {() => Promise<T | void>} fn
+ * @param {string} label
+ * @returns {Promise<T | void>}
+ */
+export async function timed(fn, label) {
+  console.log(`START: ${label}`)
+  console.time(`END: ${label}`)
+  try {
+    const res = await fn()
+    return res
+  } finally {
+    console.timeEnd(`END: ${label}`)
+  }
+}

--- a/site/wrangler.toml
+++ b/site/wrangler.toml
@@ -9,7 +9,8 @@ kv_namespaces = [
     { binding = "CSRF", preview_id = "905bd04b17bf4c739eb2250e56a1b767", id = "905bd04b17bf4c739eb2250e56a1b767" },
     { binding = "USERS", preview_id = "7e441603d1bc4d5a87f6cecb959018e4", id = "7e441603d1bc4d5a87f6cecb959018e4" },
     { binding = "NFTS", preview_id = "f1c35cd1601c452782db6056b2d35f25", id = "f1c35cd1601c452782db6056b2d35f25" },
-    { binding = "DEALS", preview_id = "ce934a65bf6a44a398980a89daf66a70", id = "ce934a65bf6a44a398980a89daf66a70" }
+    { binding = "DEALS", preview_id = "ce934a65bf6a44a398980a89daf66a70", id = "ce934a65bf6a44a398980a89daf66a70" },
+    { binding = "METRICS", preview_id = "104469a46696435bb2e7bfa201a36611", id = "104469a46696435bb2e7bfa201a36611" }
 ]
 vars = { AUTH0_CALLBACK_URL = "http://127.0.0.1:8787/auth", DEBUG = true, CLUSTER_API_URL = "", CLUSTER_IPFS_PROXY_API_URL = "", CLUSTER_ADDRS = "" }
 
@@ -29,7 +30,8 @@ kv_namespaces = [
     { binding = "SESSION", preview_id = "7cf078ca01934227abedac1b29cd385c", id = "7cf078ca01934227abedac1b29cd385c" },
     { binding = "CSRF", preview_id = "67c398acd70744a785995a59a5fcfff7", id = "67c398acd70744a785995a59a5fcfff7" },
     { binding = "NFTS", preview_id = "21763d3a9ce2465b875a49ae57a5a598", id = "21763d3a9ce2465b875a49ae57a5a598" },
-    { binding = "DEALS", preview_id = "ab1ee988b16747149e4dee6b1a07bbd2", id = "ab1ee988b16747149e4dee6b1a07bbd2" }
+    { binding = "DEALS", preview_id = "ab1ee988b16747149e4dee6b1a07bbd2", id = "ab1ee988b16747149e4dee6b1a07bbd2" },
+    { binding = "METRICS", preview_id = "f80cad90abdf4bf98b41518f1e7a6ea1", id = "f80cad90abdf4bf98b41518f1e7a6ea1" }
 ]
 
 [env.production]
@@ -40,7 +42,8 @@ kv_namespaces = [
     { binding = "CSRF", id = "a4f7fb397a0941d4ac6657515962e960", preview_id = "afc15a61a0414febafabfc724c904b50" },
     { binding = "USERS", id = "8a5a55b5d1af49ed8fcfab16e9fa8c41", preview_id = "7e441603d1bc4d5a87f6cecb959018e4" },
     { binding = "NFTS", id = "9610798d5e5845fa94e4392cc1288ddf", preview_id = "f1c35cd1601c452782db6056b2d35f25" },
-    { binding = "DEALS", id = "9d5815757b04446ab8cfbc99e6296842", preview_id = "ce934a65bf6a44a398980a89daf66a70" }
+    { binding = "DEALS", id = "9d5815757b04446ab8cfbc99e6296842", preview_id = "ce934a65bf6a44a398980a89daf66a70" },
+    { binding = "METRICS", id = "12c38488fd6047fd8bb4030a8dacb406", preview_id = "104469a46696435bb2e7bfa201a36611" }
 ]
 
 [env.alanshaw]
@@ -56,7 +59,8 @@ kv_namespaces = [
     { binding = "SESSION", preview_id = "a100ac642a854dbfa9778069fb52c800", id = "a100ac642a854dbfa9778069fb52c800" },
     { binding = "CSRF", preview_id = "82a68f45340e43f1b07768279cde909d", id = "82a68f45340e43f1b07768279cde909d" },
     { binding = "NFTS", preview_id = "c8fd3b56aa284e1395169c681a04fc91", id = "c8fd3b56aa284e1395169c681a04fc91" },
-    { binding = "DEALS", preview_id = "e8bdcf6793554671ba98cfc7eaf4a225", id = "e8bdcf6793554671ba98cfc7eaf4a225" }
+    { binding = "DEALS", preview_id = "e8bdcf6793554671ba98cfc7eaf4a225", id = "e8bdcf6793554671ba98cfc7eaf4a225" },
+    { binding = "METRICS", preview_id = "9f28491818d742a2b1363449fe39d6b7", id = "9f28491818d742a2b1363449fe39d6b7" }
 ]
 
 [site]

--- a/site/wrangler.toml
+++ b/site/wrangler.toml
@@ -13,6 +13,9 @@ kv_namespaces = [
 ]
 vars = { AUTH0_CALLBACK_URL = "http://127.0.0.1:8787/auth", DEBUG = true, CLUSTER_API_URL = "", CLUSTER_IPFS_PROXY_API_URL = "", CLUSTER_ADDRS = "" }
 
+[triggers]
+crons = ["*/10 * * * *"]
+
 [env.staging]
 name = "nft-storage-staging"
 type = "webpack"


### PR DESCRIPTION
This PR adds cron jobs for metrics generation and pin status / size tracking.

Previously the metrics were counted when the user hit the `/metrics` endpoint and then cached for 10 minutes. Now they are counted and stored in a new KV "METRICS". The `/metrics` endpoint has been updated to just read the latest values from the KV store.

The code to count metrics has also been updated to count filecoin deals in the "DEALS" KV, which resolves https://github.com/ipfs-shipyard/nft.storage/issues/59

There was a hack in the `/metrics` endpoint that was updating pin status and size for NFTs that were stored via the pinning services API. This has been pulled out into it's own dedicated cron job.