### PR TITLE
fix: store NFT metadata when NFT is new

### DIFF
--- a/site/src/models/nfts.js
+++ b/site/src/models/nfts.js
@@ -53,7 +53,7 @@ export const set = async (key, value, options) => {
   const savedValue = await get(key)
   if (savedValue === null) {
     const kvKey = encodeKey(key)
-    await stores.nfts.put(kvKey, JSON.stringify(value))
+    await stores.nfts.put(kvKey, JSON.stringify(value), options)
     await stores.nftsIndex.put(
       encodeIndexKey({ ...key, created: new Date(value.created) }),
       '',


### PR DESCRIPTION
This means we're doing a lot more unnecessary work currently in the followup cron task.