### PR TITLE
fix: better error message for missing auth token

### DIFF
--- a/site/src/utils/auth.js
+++ b/site/src/utils/auth.js
@@ -22,6 +22,9 @@ export const magic = new Magic(secrets.magic)
  */
 export async function validate(event) {
   const auth = event.request.headers.get('Authorization') || ''
+  if (!auth) {
+    throw new HTTPError('Missing auth token', 401)
+  }
   const token = magic.utils.parseAuthorizationHeader(auth)
   // validate access tokens
   if (await verifyJWT(token)) {


### PR DESCRIPTION
Instead of:

```
Magic Admin SDK Error: [EXPECTED_BEARER_STRING] Expected argument to be a string in the `Bearer {token}` format.
```