### PR TITLE
feat: pin tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ wrangler kv:namespace create DEALS --preview --env USER
 # same as above
 wrangler kv:namespace create METRICS --preview --env USER
 # same as above
+wrangler kv:namespace create PINS --preview --env USER
+# same as above
 ```
 
 Go to `/site/src/constants.js` _uncomment_ the first line and run `wrangler publish --env USER`.
@@ -178,6 +180,8 @@ wrangler kv:namespace create NFTS_IDX --env production
 wrangler kv:namespace create DEALS --env production
 # Follow the instructions from the cli output
 wrangler kv:namespace create METRICS --env production
+# Follow the instructions from the cli output
+wrangler kv:namespace create PINS --env production
 # Follow the instructions from the cli output
 wrangler secret put MAGIC_SECRET_KEY --env production # Get from magic.link account
 wrangler secret put SALT --env production # open `https://csprng.xyz/v1/api` in the browser and use the value of `Data`

--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ wrangler kv:namespace create METRICS --preview --env USER
 # same as above
 wrangler kv:namespace create PINS --preview --env USER
 # same as above
+wrangler kv:namespace create FOLLOWUPS --preview --env USER
+# same as above
 ```
 
 Go to `/site/src/constants.js` _uncomment_ the first line and run `wrangler publish --env USER`.
@@ -182,6 +184,8 @@ wrangler kv:namespace create DEALS --env production
 wrangler kv:namespace create METRICS --env production
 # Follow the instructions from the cli output
 wrangler kv:namespace create PINS --env production
+# Follow the instructions from the cli output
+wrangler kv:namespace create FOLLOWUPS --env production
 # Follow the instructions from the cli output
 wrangler secret put MAGIC_SECRET_KEY --env production # Get from magic.link account
 wrangler secret put SALT --env production # open `https://csprng.xyz/v1/api` in the browser and use the value of `Data`

--- a/migrations/000-fix-nfts-metadata.js
+++ b/migrations/000-fix-nfts-metadata.js
@@ -62,7 +62,7 @@ async function main() {
     )
     if (bulkWrites.length) {
       console.log(`💔 fixing metadata for ${bulkWrites.length} NFTs`)
-      await cf.writeMultiKV(table.id, bulkWrites)
+      await cf.writeKVMulti(table.id, bulkWrites)
     }
     total += keys.length
     console.log(`🦄 processed ${total} NFTs`)

--- a/migrations/000-fix-nfts-metadata.js
+++ b/migrations/000-fix-nfts-metadata.js
@@ -1,0 +1,68 @@
+import dotenv from 'dotenv'
+import { Cloudflare } from './cloudflare.js'
+import { findNs } from './utils.js'
+
+dotenv.config()
+
+async function main() {
+  const env = process.env.ENV || 'dev'
+  const cf = new Cloudflare({
+    accountId: process.env.CF_ACCOUNT,
+    apiToken: process.env.CF_TOKEN,
+  })
+
+  console.log(`🐶 fetching KV namespaces`)
+  const namespaces = await cf.fetchKVNamespaces()
+  const table = findNs(namespaces, env, 'NFTS')
+
+  console.log(`🎯 Fixing ${table.title}`)
+  let total = 0
+  for await (const keys of cf.fetchKVKeys(table.id)) {
+    const bulkWrites = []
+    await Promise.all(
+      keys.filter(Boolean).map(async (k) => {
+        let { metadata } = k
+        if (!metadata) {
+          console.log(`📖 reading ${k.name} to fix missing metadata`)
+          const value = await cf.readKV(table.id, k.name)
+          console.log(`📗 read ${k.name}`)
+          metadata = {
+            pinStatus: value.pin.status,
+            size: value.size,
+            created: value.created,
+          }
+          // if pinned and no size, then set to pinning in meta so cron will
+          // pick it up and update status and size.
+          if (metadata.pinStatus === 'pinned' && !metadata.size) {
+            metadata.pinStatus = 'pinning'
+          }
+          bulkWrites.push({ key: k.name, value, metadata })
+          return
+        }
+        let { created } = metadata
+        if (!created) {
+          console.log(
+            `📖 reading ${k.name} to fix missing created date in metadata`
+          )
+          const value = await cf.readKV(table.id, k.name)
+          console.log(`📗 read ${k.name}`)
+          created = value.created
+          bulkWrites.push({
+            key: k.name,
+            value,
+            metadata: { ...metadata, created },
+          })
+        }
+      })
+    )
+    if (bulkWrites.length) {
+      console.log(`💔 fixing metadata for ${bulkWrites.length} NFTs`)
+      await cf.writeMultiKV(table.id, bulkWrites)
+    }
+    total += keys.length
+    console.log(`🦄 processed ${total} NFTs`)
+  }
+  console.log('✅ done')
+}
+
+main().catch(console.error)

--- a/migrations/000-fix-nfts-metadata.js
+++ b/migrations/000-fix-nfts-metadata.js
@@ -1,3 +1,8 @@
+/**
+ * This migration ensures all the records in the NFTS table have appropriate
+ * metadata set.
+ */
+
 import dotenv from 'dotenv'
 import { Cloudflare } from './cloudflare.js'
 import { findNs } from './utils.js'

--- a/migrations/001-nfts-index.js
+++ b/migrations/001-nfts-index.js
@@ -1,5 +1,6 @@
 import dotenv from 'dotenv'
 import { Cloudflare } from './cloudflare.js'
+import { findNs } from './utils.js'
 
 dotenv.config()
 
@@ -20,90 +21,38 @@ async function main() {
   })
   console.log(`🐶 fetching KV namespaces`)
   const namespaces = await cf.fetchKVNamespaces()
-  const indexTables = namespaces.filter((ns) => ns.title.includes('NFTS_IDX'))
-  const tables = indexTables
-    .map((idxTable) => {
-      const title = idxTable.title.replace('NFTS_IDX', 'NFTS')
-      return {
-        table: namespaces.find((t) => t.title === title),
-        index: idxTable,
-      }
-    })
-    .filter((t) => {
-      if (env === 'production') {
-        return (
-          !t.table.title.includes('dev') && !t.table.title.includes('staging')
-        )
-      }
-      return t.table.title.includes(env)
-    })
+  const table = findNs(namespaces, env, 'NFTS')
+  const index = findNs(namespaces, env, 'NFTS_IDX')
 
-  for (const { table, index } of tables) {
-    console.log(`🎯 Populating ${index.title} from ${table.title}`)
-    let total = 0
-    for await (const keys of cf.fetchKVKeys(table.id)) {
-      const bulkWrites = { table: [], index: [] }
-      await Promise.all(
-        keys.map(async (k) => {
-          const [sub, cid] = k.name.split(':')
-          let { metadata } = k
-          if (!metadata) {
-            console.log(`📖 reading ${k.name} to fix missing metadata`)
-            const value = await cf.readKV(table.id, k.name)
-            console.log(`📗 read ${k.name}`)
-            metadata = {
-              pinStatus: value.pin.status,
-              size: value.size,
-              created: value.created,
-            }
-            // if pinned and no size, then set to pinning in meta so cron will
-            // pick it up and update status and size.
-            if (metadata.pinStatus === 'pinned' && !metadata.size) {
-              metadata.pinStatus = 'pinning'
-            }
-            bulkWrites.table.push({ key: k.name, value, metadata })
-          }
-          let { created } = metadata
-          if (!created) {
-            console.log(
-              `📖 reading ${k.name} to fix missing created date in metadata`
-            )
-            const value = await cf.readKV(table.id, k.name)
-            console.log(`📗 read ${k.name}`)
-            created = value.created
-            bulkWrites.table.push({
-              key: k.name,
-              value,
-              metadata: { ...metadata, created },
-            })
-          }
-          const indexKey = encodeIndexKey({
-            user: { sub },
-            created: new Date(created),
-            cid,
-          })
-          bulkWrites.index.push({
-            key: indexKey,
-            value: '',
-            metadata: { key: k.name },
-          })
+  console.log(`🎯 Populating ${index.title} from ${table.title}`)
+  let total = 0
+  for await (const keys of cf.fetchKVKeys(table.id)) {
+    const bulkWrites = []
+    await Promise.all(
+      keys.filter(Boolean).map(async (k) => {
+        const parts = k.name.split(':')
+        const cid = parts.pop()
+        const sub = parts.join(':')
+        const indexKey = encodeIndexKey({
+          user: { sub },
+          created: new Date(k.metadata.created),
+          cid,
         })
-      )
-      if (bulkWrites.table.length) {
-        console.log(`🧸 fixing metadata for ${bulkWrites.table.length} NFTs`)
-        await cf.writeMultiKV(table.id, bulkWrites.table)
-      }
-      if (bulkWrites.index.length) {
-        console.log(
-          `🗂 writing index entries for NFTs ${total} -> ${
-            total + bulkWrites.index.length
-          }`
-        )
-        await cf.writeMultiKV(index.id, bulkWrites.index)
-      }
-      total += bulkWrites.index.length
+        bulkWrites.push({
+          key: indexKey,
+          value: '',
+          metadata: { key: k.name },
+        })
+      })
+    )
+    if (bulkWrites.length) {
+      console.log(`🗂 writing index entries for ${bulkWrites.length} NFTs`)
+      await cf.writeMultiKV(index.id, bulkWrites)
     }
+    total += keys.length
+    console.log(`🦄 processed ${total} NFTs`)
   }
+  console.log('✅ done')
 }
 
 main().catch(console.error)

--- a/migrations/001-nfts-index.js
+++ b/migrations/001-nfts-index.js
@@ -1,3 +1,11 @@
+/**
+ * This migration populates the NFTS_IDX table by reading all the records in
+ * the NFTS table.
+ *
+ * The NFTS_IDX table is an indexing table, with keys ordered by user.sub and
+ * then by created date (DESC).
+ */
+
 import dotenv from 'dotenv'
 import { Cloudflare } from './cloudflare.js'
 import { findNs } from './utils.js'

--- a/migrations/001-nfts-index.js
+++ b/migrations/001-nfts-index.js
@@ -55,7 +55,7 @@ async function main() {
     )
     if (bulkWrites.length) {
       console.log(`🗂 writing index entries for ${bulkWrites.length} NFTs`)
-      await cf.writeMultiKV(index.id, bulkWrites)
+      await cf.writeKVMulti(index.id, bulkWrites)
     }
     total += keys.length
     console.log(`🦄 processed ${total} NFTs`)

--- a/migrations/002-pins.js
+++ b/migrations/002-pins.js
@@ -1,3 +1,9 @@
+/**
+ * This migration populates the PINS table using data in the NFTS table. It also
+ * adds records to the FOLLOWUPS table if any pins need to be followed up on
+ * because they are not yet pinned or have no size.
+ */
+
 import dotenv from 'dotenv'
 import { Cloudflare } from './cloudflare.js'
 import { findNs } from './utils.js'
@@ -14,17 +20,30 @@ async function main() {
   const namespaces = await cf.fetchKVNamespaces()
   const nftsTable = findNs(namespaces, env, 'NFTS')
   const pinsTable = findNs(namespaces, env, 'PINS')
+  const followupsTable = findNs(namespaces, env, 'FOLLOWUPS')
 
   console.log(`🎯 Populating ${pinsTable.title} from ${nftsTable.title}`)
   let total = 0
   for await (const keys of cf.fetchKVKeys(nftsTable.id)) {
-    const bulkWrites = []
+    const seen = new Set()
+    const bulkWrites = { pins: [], followups: [] }
     keys.filter(Boolean).forEach((k) => {
       const cid = k.name.split(':').pop()
-      const seen = bulkWrites.some((w) => w.key === cid)
-      if (seen) return
-      bulkWrites.push({
-        key: `${k.metadata.pinStatus}:${cid}`,
+      if (seen.has(cid)) return
+      seen.add(cid)
+      if (!isPinnedOrFailed(k.metadata.pinStatus) || !k.metadata.size) {
+        bulkWrites.followups.push({
+          key: cid,
+          value: '',
+          metadata: {
+            status: k.metadata.pinStatus,
+            size: k.metadata.size,
+            created: k.metadata.created,
+          },
+        })
+      }
+      bulkWrites.pins.push({
+        key: cid,
         value: '',
         metadata: {
           status: k.metadata.pinStatus,
@@ -33,9 +52,15 @@ async function main() {
         },
       })
     })
-    if (bulkWrites.length) {
-      console.log(`🗂 writing pin values for ${bulkWrites.length} NFTs`)
-      await cf.writeMultiKV(pinsTable.id, bulkWrites)
+    if (bulkWrites.pins.length) {
+      console.log(`🗂 writing pin values for ${bulkWrites.pins.length} NFTs`)
+      await cf.writeMultiKV(pinsTable.id, bulkWrites.pins)
+    }
+    if (bulkWrites.followups.length) {
+      console.log(
+        `🔁 writing followup values for ${bulkWrites.followups.length} pins`
+      )
+      await cf.writeMultiKV(followupsTable.id, bulkWrites.followups)
     }
     total += keys.length
     console.log(`🦄 processed ${total} NFTs`)
@@ -44,3 +69,7 @@ async function main() {
 }
 
 main().catch(console.error)
+
+function isPinnedOrFailed(status) {
+  return status === 'pinned' || status === 'failed'
+}

--- a/migrations/002-pins.js
+++ b/migrations/002-pins.js
@@ -54,13 +54,13 @@ async function main() {
     })
     if (bulkWrites.pins.length) {
       console.log(`🗂 writing pin values for ${bulkWrites.pins.length} NFTs`)
-      await cf.writeMultiKV(pinsTable.id, bulkWrites.pins)
+      await cf.writeKVMulti(pinsTable.id, bulkWrites.pins)
     }
     if (bulkWrites.followups.length) {
       console.log(
         `🔁 writing followup values for ${bulkWrites.followups.length} pins`
       )
-      await cf.writeMultiKV(followupsTable.id, bulkWrites.followups)
+      await cf.writeKVMulti(followupsTable.id, bulkWrites.followups)
     }
     total += keys.length
     console.log(`🦄 processed ${total} NFTs`)

--- a/migrations/002-pins.js
+++ b/migrations/002-pins.js
@@ -1,0 +1,46 @@
+import dotenv from 'dotenv'
+import { Cloudflare } from './cloudflare.js'
+import { findNs } from './utils.js'
+
+dotenv.config()
+
+async function main() {
+  const env = process.env.ENV || 'dev'
+  const cf = new Cloudflare({
+    accountId: process.env.CF_ACCOUNT,
+    apiToken: process.env.CF_TOKEN,
+  })
+  console.log(`🐶 fetching KV namespaces`)
+  const namespaces = await cf.fetchKVNamespaces()
+  const nftsTable = findNs(namespaces, env, 'NFTS')
+  const pinsTable = findNs(namespaces, env, 'PINS')
+
+  console.log(`🎯 Populating ${pinsTable.title} from ${nftsTable.title}`)
+  let total = 0
+  for await (const keys of cf.fetchKVKeys(nftsTable.id)) {
+    const bulkWrites = []
+    keys.filter(Boolean).forEach((k) => {
+      const cid = k.name.split(':').pop()
+      const seen = bulkWrites.some((w) => w.key === cid)
+      if (seen) return
+      bulkWrites.push({
+        key: `${k.metadata.pinStatus}:${cid}`,
+        value: '',
+        metadata: {
+          status: k.metadata.pinStatus,
+          size: k.metadata.size,
+          created: k.metadata.created,
+        },
+      })
+    })
+    if (bulkWrites.length) {
+      console.log(`🗂 writing pin values for ${bulkWrites.length} NFTs`)
+      await cf.writeMultiKV(pinsTable.id, bulkWrites)
+    }
+    total += keys.length
+    console.log(`🦄 processed ${total} NFTs`)
+  }
+  console.log('✅ done')
+}
+
+main().catch(console.error)

--- a/migrations/002-pins.js
+++ b/migrations/002-pins.js
@@ -36,6 +36,7 @@ async function main() {
           key: cid,
           value: '',
           metadata: {
+            cid,
             status: k.metadata.pinStatus,
             size: k.metadata.size,
             created: k.metadata.created,
@@ -46,6 +47,7 @@ async function main() {
         key: cid,
         value: '',
         metadata: {
+          cid,
           status: k.metadata.pinStatus,
           size: k.metadata.size,
           created: k.metadata.created,

--- a/migrations/003-add-nfts-meta-to-index.js
+++ b/migrations/003-add-nfts-meta-to-index.js
@@ -1,0 +1,56 @@
+/**
+ * This migration adds the metadata stored in NFTS to the NFTS_IDX where it is
+ * needed.
+ *
+ * Note: metadata in NFTS is no longer needed/used but we're just going to leave
+ * it where it is.
+ */
+
+import dotenv from 'dotenv'
+import { Cloudflare } from './cloudflare.js'
+import { findNs } from './utils.js'
+
+dotenv.config()
+
+async function main() {
+  const env = process.env.ENV || 'dev'
+  const cf = new Cloudflare({
+    accountId: process.env.CF_ACCOUNT,
+    apiToken: process.env.CF_TOKEN,
+  })
+  console.log(`🐶 fetching KV namespaces`)
+  const namespaces = await cf.fetchKVNamespaces()
+  const nftsTable = findNs(namespaces, env, 'NFTS')
+  const nftsIdxTable = findNs(namespaces, env, 'NFTS_IDX')
+
+  const nftsMeta = new Map()
+  let i = 0
+  for await (const keys of cf.fetchKVKeys(nftsTable.id)) {
+    console.log(`💰 caching metadata for ${i} -> ${i + keys.length} NFTs`)
+    keys.filter(Boolean).forEach((k) => nftsMeta.set(k.name, k.metadata))
+    i += keys.length
+  }
+
+  console.log(`🎯 Updating ${nftsIdxTable.title} from ${nftsTable.title}`)
+  let total = 0
+  for await (const keys of cf.fetchKVKeys(nftsIdxTable.id)) {
+    const bulkWrites = []
+    keys.filter(Boolean).forEach((k) => {
+      const { key } = k.metadata
+      const meta = nftsMeta.get(key)
+      if (!meta) {
+        return console.warn(`❗️ missing metadata for ${key}`)
+      }
+      bulkWrites.push({ key, value: '', metadata: { ...k.metadata, ...meta } })
+    })
+    if (bulkWrites.pins.length) {
+      console.log(`🗂 updating index metadata for ${bulkWrites.length} NFTs`)
+      await cf.writeMultiKV(nftsIdxTable.id, bulkWrites)
+    }
+    total += keys.length
+    console.log(`🦄 processed ${total} NFTs`)
+  }
+  console.log('✅ done')
+}
+
+main().catch(console.error)

--- a/migrations/003-add-nfts-meta-to-index.js
+++ b/migrations/003-add-nfts-meta-to-index.js
@@ -43,7 +43,7 @@ async function main() {
       }
       bulkWrites.push({ key, value: '', metadata: { ...k.metadata, ...meta } })
     })
-    if (bulkWrites.pins.length) {
+    if (bulkWrites.length) {
       console.log(`🗂 updating index metadata for ${bulkWrites.length} NFTs`)
       await cf.writeMultiKV(nftsIdxTable.id, bulkWrites)
     }

--- a/migrations/004-reindex-nfts.js
+++ b/migrations/004-reindex-nfts.js
@@ -68,7 +68,7 @@ async function main() {
     )
     if (bulkWrites.length) {
       console.log(`🗂 writing index entries for ${bulkWrites.length} NFTs`)
-      await cf.writeMultiKV(index.id, bulkWrites)
+      await cf.writeKVMulti(index.id, bulkWrites)
     }
     total += keys.length
     console.log(`🦄 processed ${total} NFTs`)

--- a/migrations/004-reindex-nfts.js
+++ b/migrations/004-reindex-nfts.js
@@ -1,0 +1,79 @@
+/**
+ * This is an optional migration that can be used to re-index data in NFTS_IDX
+ * based on data in NFTS and PINS.
+ */
+
+import dotenv from 'dotenv'
+import { Cloudflare } from './cloudflare.js'
+import { findNs } from './utils.js'
+
+dotenv.config()
+
+const FAR_FUTURE = new Date('3000-01-01T00:00:00.000Z').getTime()
+const PAD_LEN = FAR_FUTURE.toString().length
+
+// TODO: can be imported when https://github.com/ipfs-shipyard/nft.storage/pull/65 is merged
+function encodeIndexKey({ user, created, cid }) {
+  const ts = (FAR_FUTURE - created.getTime()).toString().padStart(PAD_LEN, '0')
+  return `${user.sub}:${ts}:${cid}`
+}
+
+async function main() {
+  const env = process.env.ENV || 'dev'
+  const cf = new Cloudflare({
+    accountId: process.env.CF_ACCOUNT,
+    apiToken: process.env.CF_TOKEN,
+  })
+  console.log(`🐶 fetching KV namespaces`)
+  const namespaces = await cf.fetchKVNamespaces()
+  const table = findNs(namespaces, env, 'NFTS')
+  const index = findNs(namespaces, env, 'NFTS_IDX')
+  const pins = findNs(namespaces, env, 'PINS')
+
+  console.log(
+    `🎯 Populating ${index.title} from ${table.title} and ${pins.title}`
+  )
+  let total = 0
+  for await (const keys of cf.fetchKVKeys(table.id)) {
+    const bulkWrites = []
+    await Promise.all(
+      keys.filter(Boolean).map(async (k) => {
+        const parts = k.name.split(':')
+        const cid = parts.pop()
+        const sub = parts.join(':')
+        console.log(`📖 reading NFT and pin for ${k.name}`)
+        const [nft, pin] = await Promise.all([
+          cf.readKV(table.id, k.name),
+          cf.readKVMeta(pins.id, cid),
+        ])
+        if (!nft) throw new Error(`missing NFT ${k.name}`)
+        if (!pin) throw new Error(`missing pin ${cid}`)
+        const indexKey = encodeIndexKey({
+          user: { sub },
+          created: new Date(nft.created),
+          cid,
+        })
+        bulkWrites.push({
+          key: indexKey,
+          value: '',
+          metadata: {
+            key: k.name,
+            pinStatus: pin.status,
+            size: pin.size,
+            name: pin.name,
+            meta: pin.meta,
+          },
+        })
+      })
+    )
+    if (bulkWrites.length) {
+      console.log(`🗂 writing index entries for ${bulkWrites.length} NFTs`)
+      await cf.writeMultiKV(index.id, bulkWrites)
+    }
+    total += keys.length
+    console.log(`🦄 processed ${total} NFTs`)
+  }
+  console.log('✅ done')
+}
+
+main().catch(console.error)

--- a/migrations/cloudflare.js
+++ b/migrations/cloudflare.js
@@ -98,7 +98,7 @@ export class Cloudflare {
     await this.fetchJSON(url.toString(), { method: 'PUT', body })
   }
 
-  async writeMultiKV(nsId, kvs) {
+  async writeKVMulti(nsId, kvs) {
     const url = new URL(`${this.kvNsPath}/${nsId}/bulk`, endpoint)
     kvs = kvs.map((kv) => ({ ...kv, value: JSON.stringify(kv.value) }))
     return this.fetchJSON(url.toString(), {
@@ -125,5 +125,14 @@ export class Cloudflare {
     )
     const { result } = await this.fetchJSON(url.toString())
     return result.length ? result[0].metadata : null
+  }
+
+  async deleteKVMulti(nsId, keys) {
+    const url = new URL(`${this.kvNsPath}/${nsId}/bulk`, endpoint)
+    return this.fetchJSON(url.toString(), {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(keys),
+    })
   }
 }

--- a/migrations/cloudflare.js
+++ b/migrations/cloudflare.js
@@ -29,9 +29,11 @@ export class Cloudflare {
                 init.signal = controller.signal
                 try {
                   const res = await fetch(url, init)
-                  if (!res.ok)
+                  if (!res.ok) {
                     throw new Error(`${res.status}: ${res.statusText}`)
-                  return await res.json()
+                  }
+                  const text = await res.text()
+                  return text === '' ? null : JSON.parse(text)
                 } finally {
                   clearTimeout(abortID)
                 }

--- a/migrations/cloudflare.js
+++ b/migrations/cloudflare.js
@@ -39,11 +39,7 @@ export class Cloudflare {
                 }
               },
               {
-                onFailedAttempt: (err) => {
-                  console.log(
-                    `💥 fetch ${url} attempt ${err.attemptNumber} failed: ${err.retriesLeft} retries left.`
-                  )
-                },
+                onFailedAttempt: (err) => console.warn(`💥 fetch ${url}`, err),
                 retries: 5,
               }
             )
@@ -118,5 +114,16 @@ export class Cloudflare {
       endpoint
     )
     return this.fetchJSON(url.toString())
+  }
+
+  async readKVMeta(nsId, key) {
+    const url = new URL(
+      `${this.kvNsPath}/${nsId}/keys?limit=10&prefix=${encodeURIComponent(
+        key
+      )}`,
+      endpoint
+    )
+    const { result } = await this.fetchJSON(url.toString())
+    return result.length ? result[0].metadata : null
   }
 }

--- a/migrations/cloudflare.js
+++ b/migrations/cloudflare.js
@@ -27,11 +27,14 @@ export class Cloudflare {
                 init.headers = init.headers || {}
                 init.headers.Authorization = `Bearer ${apiToken}`
                 init.signal = controller.signal
-                const res = await fetch(url, init)
-                if (!res.ok) throw new Error(`${res.status}: ${res.statusText}`)
-                const data = await res.json()
-                clearTimeout(abortID)
-                return data
+                try {
+                  const res = await fetch(url, init)
+                  if (!res.ok)
+                    throw new Error(`${res.status}: ${res.statusText}`)
+                  return await res.json()
+                } finally {
+                  clearTimeout(abortID)
+                }
               },
               {
                 onFailedAttempt: (err) => {

--- a/migrations/show-table.js
+++ b/migrations/show-table.js
@@ -1,0 +1,47 @@
+/**
+ * Utility to list a KV namespace's keys, values and metadata.
+ *
+ * Usage:
+ *     node show-table.js NFTS
+ *     node show-table.js DEALS --only-meta
+ */
+import dotenv from 'dotenv'
+import { Cloudflare } from './cloudflare.js'
+import { findNs } from './utils.js'
+
+dotenv.config()
+
+async function main() {
+  const env = process.env.ENV || 'dev'
+  const tableName = process.argv[2]
+  const onlyMeta = process.argv[3] === '--only-meta'
+  const cf = new Cloudflare({
+    accountId: process.env.CF_ACCOUNT,
+    apiToken: process.env.CF_TOKEN,
+  })
+  const namespaces = await cf.fetchKVNamespaces()
+  const table = findNs(namespaces, env, tableName)
+  console.log(`🪑 ${table.title}`)
+
+  let i = 0
+  for await (const keys of cf.fetchKVKeys(table.id)) {
+    i += keys.length
+    for (const k of keys) {
+      if (onlyMeta) {
+        console.log(
+          `${k.name}\t${k.metadata ? JSON.stringify(k.metadata) : ''}`
+        )
+      } else {
+        const value = await cf.readKV(table.id, k.name)
+        console.log(
+          `${k.name}\t${JSON.stringify(value)}\t${
+            k.metadata ? JSON.stringify(k.metadata) : ''
+          }`
+        )
+      }
+    }
+  }
+  console.log(`${i} total`)
+}
+
+main().catch(console.error)

--- a/migrations/tools/empty-table.js
+++ b/migrations/tools/empty-table.js
@@ -1,0 +1,39 @@
+/**
+ * Utility to remove all content from a KV namespace.
+ *
+ * Usage:
+ *     node empty-table.js NFTS_IDX
+ */
+import dotenv from 'dotenv'
+import { Cloudflare } from '../cloudflare.js'
+import { findNs } from '../utils.js'
+
+dotenv.config()
+
+async function main() {
+  const env = process.env.ENV || 'dev'
+  if (env === 'production') {
+    throw new Error('refusing to empty production KV')
+  }
+  const tableName = process.argv[2]
+  const cf = new Cloudflare({
+    accountId: process.env.CF_ACCOUNT,
+    apiToken: process.env.CF_TOKEN,
+  })
+  const namespaces = await cf.fetchKVNamespaces()
+  const table = findNs(namespaces, env, tableName)
+  console.log(`🪑 ${table.title}`)
+
+  let i = 0
+  for await (const keys of cf.fetchKVKeys(table.id)) {
+    console.log(`🗑 removing keys ${i} -> ${i + keys.length}`)
+    await cf.deleteKVMulti(
+      table.id,
+      keys.filter(Boolean).map((k) => k.name)
+    )
+    i += keys.length
+  }
+  console.log(`${i} total`)
+}
+
+main().catch(console.error)

--- a/migrations/tools/show-table.js
+++ b/migrations/tools/show-table.js
@@ -6,8 +6,8 @@
  *     node show-table.js DEALS --only-meta
  */
 import dotenv from 'dotenv'
-import { Cloudflare } from './cloudflare.js'
-import { findNs } from './utils.js'
+import { Cloudflare } from '../cloudflare.js'
+import { findNs } from '../utils.js'
 
 dotenv.config()
 

--- a/migrations/utils.js
+++ b/migrations/utils.js
@@ -1,7 +1,7 @@
 export function findNs(namespaces, env, name) {
-  const prefix = env === 'production' ? '' : `-${env}-`
+  const prefix = env === 'production' ? '' : `${env}-`
   const suffix = env === 'production' ? '' : '_preview'
-  const fqn = `nft-storage${prefix}${name}${suffix}`
+  const fqn = `nft-storage-${prefix}${name}${suffix}`
   const ns = namespaces.find((ns) => ns.title === fqn)
   if (!ns) throw new Error(`KV namespace ${fqn} not found`)
   return ns

--- a/migrations/utils.js
+++ b/migrations/utils.js
@@ -1,0 +1,8 @@
+export function findNs(namespaces, env, name) {
+  const prefix = env === 'production' ? '' : `-${env}-`
+  const suffix = env === 'production' ? '' : '_preview'
+  const fqn = `nft-storage${prefix}${name}${suffix}`
+  const ns = namespaces.find((ns) => ns.title === fqn)
+  if (!ns) throw new Error(`KV namespace ${fqn} not found`)
+  return ns
+}

--- a/site/src/bindings.d.ts
+++ b/site/src/bindings.d.ts
@@ -68,6 +68,12 @@ export type NFT = {
   created: string
 }
 
+export type NFTResponse = NFT & {
+  size: number
+  pin: Pin
+  deals: Deal[]
+}
+
 export type { Deal }
 
 export interface User {

--- a/site/src/bindings.d.ts
+++ b/site/src/bindings.d.ts
@@ -11,6 +11,8 @@ declare global {
   const NFTS: KVNamespace
   const NFTS_IDX: KVNamespace
   const METRICS: KVNamespace
+  const PINS: KVNamespace
+  const FOLLOWUPS: KVNamespace
   const PINATA_JWT: string
   const CLUSTER_API_URL: string
   const CLUSTER_BASIC_AUTH_TOKEN: string
@@ -45,10 +47,6 @@ export type NFT = {
    */
   cid: string
   /**
-   * Size in bytes of the NFT data.
-   */
-  size: number
-  /**
    * Type of the data: "directory" or Blob.type.
    */
   type: string
@@ -57,9 +55,9 @@ export type NFT = {
    */
   files: Array<{ name: string; type: string }>
   /**
-   * Pinata pin data.
+   * Pinata pin name and meta.
    */
-  pin: Pin
+  pin?: { name?: string; meta?: Record<string, string> }
   /**
    * Name of the JWT token used to create this NFT.
    */
@@ -68,16 +66,6 @@ export type NFT = {
    * Date this NFT was created in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: YYYY-MM-DDTHH:MM:SSZ.
    */
   created: string
-  /**
-   * Deals
-   */
-  deals?: {
-    /**
-     * Overall deal status
-     */
-    status: 'ongoing' | 'finalized'
-    deals: Deal[]
-  }
 }
 
 export type { Deal }

--- a/site/src/constants.js
+++ b/site/src/constants.js
@@ -5,6 +5,8 @@ export const stores = {
   nfts: NFTS,
   nftsIndex: NFTS_IDX,
   metrics: METRICS,
+  pins: PINS,
+  followups: FOLLOWUPS,
 }
 
 export const secrets = {

--- a/site/src/index.js
+++ b/site/src/index.js
@@ -21,6 +21,7 @@ import {
   updateUserMetrics,
   updateNftMetrics,
   updateNftDealMetrics,
+  updatePinMetrics,
 } from './jobs/metrics.js'
 import { updatePinStatuses } from './jobs/pins.js'
 import { login } from './routes/login.js'
@@ -90,15 +91,18 @@ r.add('all', '*', notFound)
 addEventListener('fetch', r.listen.bind(r))
 
 // Cron jobs
-addEventListener('scheduled', (event) =>
+addEventListener('scheduled', (event) => {
+  const sentry = getSentrySchedule(event)
   event.waitUntil(
-    (async () => {
-      const sentry = getSentrySchedule(event)
-      await timed(updateUserMetrics, 'CRON updateUserMetrics', { sentry })
-      await timed(updateNftMetrics, 'CRON updateNftMetrics', { sentry })
-    })()
+    timed(updateUserMetrics, 'CRON updateUserMetrics', { sentry })
   )
-)
+})
+addEventListener('scheduled', (event) => {
+  const sentry = getSentrySchedule(event)
+  event.waitUntil(
+    timed(updateNftMetrics, 'CRON updateNftMetrics', { sentry })
+  )
+})
 addEventListener('scheduled', (event) => {
   const sentry = getSentrySchedule(event)
   event.waitUntil(
@@ -109,5 +113,11 @@ addEventListener('scheduled', (event) => {
   const sentry = getSentrySchedule(event)
   event.waitUntil(
     timed(updatePinStatuses, 'CRON updatePinStatuses', { sentry })
+  )
+})
+addEventListener('scheduled', (event) => {
+  const sentry = getSentrySchedule(event)
+  event.waitUntil(
+    timed(updatePinMetrics, 'CRON updatePinMetrics', { sentry })
   )
 })

--- a/site/src/index.js
+++ b/site/src/index.js
@@ -26,6 +26,7 @@ import {
 import { updatePinStatuses } from './jobs/pins.js'
 import { login } from './routes/login.js'
 import { JSONResponse } from './utils/json-response.js'
+import { updateNftsIndexMeta } from './jobs/nfts-index.js'
 const { debug, getSentrySchedule } = require('./utils/debug')
 const log = debug('router')
 
@@ -99,9 +100,7 @@ addEventListener('scheduled', (event) => {
 })
 addEventListener('scheduled', (event) => {
   const sentry = getSentrySchedule(event)
-  event.waitUntil(
-    timed(updateNftMetrics, 'CRON updateNftMetrics', { sentry })
-  )
+  event.waitUntil(timed(updateNftMetrics, 'CRON updateNftMetrics', { sentry }))
 })
 addEventListener('scheduled', (event) => {
   const sentry = getSentrySchedule(event)
@@ -117,7 +116,11 @@ addEventListener('scheduled', (event) => {
 })
 addEventListener('scheduled', (event) => {
   const sentry = getSentrySchedule(event)
+  event.waitUntil(timed(updatePinMetrics, 'CRON updatePinMetrics', { sentry }))
+})
+addEventListener('scheduled', (event) => {
+  const sentry = getSentrySchedule(event)
   event.waitUntil(
-    timed(updatePinMetrics, 'CRON updatePinMetrics', { sentry })
+    timed(updateNftsIndexMeta, 'CRON updateNftsIndexMeta', { sentry })
   )
 })

--- a/site/src/jobs/metrics.js
+++ b/site/src/jobs/metrics.js
@@ -1,6 +1,7 @@
 import { stores } from '../constants.js'
 import * as metrics from '../models/metrics.js'
 import * as deals from '../models/deals.js'
+import * as pins from '../models/pins.js'
 
 /**
  * @typedef {{
@@ -57,6 +58,28 @@ export async function updateNftMetrics() {
     metrics.set('nfts:totalBytes', totalBytes),
     // Total number of NFTs pinned on IPFS
     metrics.set('nfts:pins:total', totalPins),
+  ])
+}
+
+export async function updatePinMetrics() {
+  let total = 0
+  let totalBytes = 0
+  let statusTotals = { queued: 0, failed: 0, pinning: 0, pinned: 0 }
+  for await (const [, pin] of pins.entries()) {
+    total++
+    totalBytes += pin.size
+    statusTotals[pin.status]++
+  }
+  await Promise.all([
+    // Total number of pins added to nft.storage
+    metrics.set('pins:total', total),
+    // Total bytes of all pins
+    metrics.set('pins:totalBytes', totalBytes),
+    // Total pins by status
+    metrics.set('pins:status:queued:total', statusTotals.queued),
+    metrics.set('pins:status:failed:total', statusTotals.failed),
+    metrics.set('pins:status:pinning:total', statusTotals.pinning),
+    metrics.set('pins:status:pinned:total', statusTotals.pinned),
   ])
 }
 

--- a/site/src/jobs/metrics.js
+++ b/site/src/jobs/metrics.js
@@ -1,7 +1,7 @@
 import { stores } from '../constants.js'
 import * as metrics from '../models/metrics.js'
-import * as deals from '../models/deals.js'
 import * as pins from '../models/pins.js'
+import * as nftsIndex from '../models/nfts-index.js'
 
 /**
  * @typedef {{
@@ -35,21 +35,12 @@ export async function updateNftMetrics() {
   let total = 0
   let totalBytes = 0
   let totalPins = 0
-  let done = false
-  let cursor
-  while (!done) {
-    // @ts-ignore
-    const nftList = await stores.nfts.list({ cursor, limit: 1000 })
-    total += nftList.keys.length
-    for (const k of nftList.keys) {
-      if (!k.metadata) continue
-      totalBytes += k.metadata.size || 0
-      if (k.metadata.pinStatus === 'pinned') {
-        totalPins++
-      }
+  for await (const [, data] of nftsIndex.entries()) {
+    total++
+    totalBytes += data.size
+    if (data.pinStatus === 'pinned') {
+      totalPins++
     }
-    cursor = nftList.cursor
-    done = nftList.list_complete
   }
   await Promise.all([
     // Total number of NFTs stored on nft.storage

--- a/site/src/jobs/nfts-index.js
+++ b/site/src/jobs/nfts-index.js
@@ -1,0 +1,48 @@
+import * as pins from '../models/pins.js'
+import { stores } from '../constants.js'
+import * as nftsIndex from '../models/nfts-index.js'
+
+/**
+ * Adds and updates NFT metadata in the NFTS_IDX table. The metadata extracted
+ * is used by the Pinning Services API pins listing.
+ *
+ * @param {import('../bindings.js').RouteContext} ctx
+ */
+export async function updateNftsIndexMeta({ sentry }) {
+  for await (const [key, data] of nftsIndex.entries()) {
+    try {
+      if (isPinnedOrFailed(data.pinStatus)) {
+        continue
+      }
+      const pin = await pins.get(key.cid)
+      if (!pin) {
+        throw new Error(`missing pin for ${key.cid}`)
+      }
+      // no change
+      if (pin.status === data.pinStatus) {
+        continue
+      }
+      /** @type import('../bindings.js').NFT | null */
+      const nft = await stores.nfts.get(key.cid, 'json')
+      if (!nft) {
+        throw new Error(`missing nft for ${key.cid}`)
+      }
+      await nftsIndex.set(key, {
+        ...data, // key (in NFTS)
+        ...(nft.pin || {}), // name/meta
+        pinStatus: pin.status,
+        size: pin.size,
+      })
+    } catch (err) {
+      console.error(err)
+      sentry.captureException(err)
+    }
+  }
+}
+
+/**
+ * @param {string} [status]
+ */
+function isPinnedOrFailed(status) {
+  return status ? ['pinned', 'failed'].includes(status) : false
+}

--- a/site/src/jobs/pins.js
+++ b/site/src/jobs/pins.js
@@ -1,45 +1,30 @@
-import { stores } from '../constants.js'
 import * as cluster from '../cluster.js'
+import * as pins from '../models/pins.js'
+import * as followups from '../models/followups.js'
 
 export async function updatePinStatuses() {
-  let done = false
-  let cursor
-  while (!done) {
-    // @ts-ignore
-    const nftList = await stores.nfts.list({ cursor, limit: 1000 })
-    for (const k of nftList.keys) {
-      const cid = k.name.split(':').pop()
-      // Look up size for pinned data via pinning service API
-      if (k.metadata == null || !isPinnedOrFailed(k.metadata.pinStatus)) {
-        try {
-          const pinStatus = cluster.toPSAStatus(await cluster.status(cid))
-          if (!isPinnedOrFailed(pinStatus)) continue
-          const d = await stores.nfts.getWithMetadata(k.name)
-          if (d.value == null) throw new Error('missing NFT')
-          /** @type import('../bindings').NFT */
-          const nft = JSON.parse(d.value)
-          const prevStatus = nft.pin.status
-          nft.pin.status = pinStatus
-          const prevSize = nft.size
-          if (pinStatus === 'pinned') {
-            // for successful pin we can update the size
-            nft.size = nft.pin.size = nft.size || (await cluster.dagSize(cid))
-          }
-          // @ts-ignore
-          const metadata = { ...(d.metadata || {}), pinStatus, size: nft.size }
-          await stores.nfts.put(k.name, JSON.stringify(nft), { metadata })
-          console.log(
-            `${cid}: pin status ${prevStatus} => ${nft.pin.status}, size ${prevSize} => ${nft.size}`
-          )
-        } catch (err) {
-          console.error(
-            `${cid}: failed to update pin status and size: ${err.stack}`
-          )
-        }
+  for await (const [cid, pin] of followups.entries()) {
+    try {
+      const pinStatus = cluster.toPSAStatus(await cluster.status(cid))
+      if (pinStatus === pin.status) continue // not changed since last check
+      const prevPin = { ...pin }
+      pin.status = pinStatus
+      // for successful pin we can update the size
+      if (pinStatus === 'pinned') {
+        pin.size = await cluster.dagSize(cid)
       }
+      await pins.set(cid, pin) // Note: sets followup if status is not pinned or failed
+      if (isPinnedOrFailed(pin.status)) {
+        await followups.remove(cid)
+      }
+      console.log(
+        `${cid}: status ${prevPin.status} => ${pin.status}, size ${prevPin.size} => ${pin.size}`
+      )
+    } catch (err) {
+      console.error(
+        `${cid}: failed to update pin status and size: ${err.stack}`
+      )
     }
-    cursor = nftList.cursor
-    done = nftList.list_complete
   }
 }
 

--- a/site/src/models/followups.js
+++ b/site/src/models/followups.js
@@ -1,0 +1,26 @@
+import { stores } from '../constants'
+
+/**
+ * @returns {AsyncIterable<[string, import("./pins").Pin]>}
+ */
+export async function* entries() {
+  let done = false
+  let cursor
+  while (!done) {
+    // @ts-ignore
+    const list = await stores.followups.list({ cursor })
+    for (const k of list.keys) {
+      if (k == null) continue
+      yield [k.name, k.metadata]
+    }
+    cursor = list.cursor
+    done = list.list_complete
+  }
+}
+
+/**
+ * @param {string} cid
+ */
+export async function remove(cid) {
+  await stores.followups.delete(cid)
+}

--- a/site/src/models/nfts-index.js
+++ b/site/src/models/nfts-index.js
@@ -3,8 +3,8 @@ import { stores } from '../constants.js'
 /**
  * @typedef {{
  *   key: string
- *   pinStatus?: import('../bindings').PinStatus
- *   size?: number
+ *   pinStatus: import('../bindings').PinStatus
+ *   size: number
  *   name?: string
  *   meta?: Record<string, string>
  * }} IndexData

--- a/site/src/models/nfts-index.js
+++ b/site/src/models/nfts-index.js
@@ -1,0 +1,72 @@
+import { stores } from '../constants.js'
+
+/**
+ * @typedef {{
+ *   key: string
+ *   pinStatus?: import('../bindings').PinStatus
+ *   size?: number
+ *   name?: string
+ *   meta?: Record<string, string>
+ * }} IndexData
+ * @typedef {{ user: { sub: string }, created: string, cid: string }} Key
+ */
+
+const FAR_FUTURE = new Date('3000-01-01T00:00:00.000Z').getTime()
+const PAD_LEN = FAR_FUTURE.toString().length
+
+/**
+ * @param {Key} key
+ */
+function encodeIndexKey({ user, created, cid }) {
+  const createdTime = new Date(created).getTime()
+  const ts = (FAR_FUTURE - createdTime).toString().padStart(PAD_LEN, '0')
+  return `${user.sub}:${ts}:${cid}`
+}
+
+/**
+ * @param {string} key
+ * @returns {Key}
+ */
+function decodeIndexKey(key) {
+  const parts = key.split(':')
+  const cid = parts.pop()
+  const ts = parts.pop()
+  if (!cid || !ts) throw new Error('invalid index key')
+  const created = new Date(FAR_FUTURE - parseInt(ts)).toISOString()
+  return { user: { sub: parts.join(':') }, created, cid }
+}
+
+/**
+ * @param {Key} key
+ * @param {IndexData} data
+ * @returns {Promise<void>}
+ */
+export async function set(key, data) {
+  await stores.nftsIndex.put(encodeIndexKey(key), '', { metadata: data })
+}
+
+/**
+ * @param {Key} key
+ */
+export async function remove(key) {
+  await stores.nftsIndex.delete(encodeIndexKey(key))
+}
+
+/**
+ * @param {string} [prefix]
+ * @returns {AsyncIterable<[Key, IndexData]>}
+ */
+export async function* entries(prefix) {
+  let done = false
+  let cursor
+  while (!done) {
+    // @ts-ignore
+    const list = await stores.nftsIndex.list({ prefix, cursor })
+    for (const k of list.keys) {
+      if (k == null) continue
+      yield [decodeIndexKey(k.name), k.metadata]
+    }
+    cursor = list.cursor
+    done = list.list_complete
+  }
+}

--- a/site/src/models/pins.js
+++ b/site/src/models/pins.js
@@ -1,0 +1,47 @@
+import { stores } from '../constants.js'
+
+/** @typedef {{ status: import('../bindings.js').PinStatus, size: number, created: string }} Pin */
+
+/**
+ * @param {string} cid CID of the pin
+ * @returns {Promise<Pin>}
+ */
+export const get = async (cid) => {
+  const { metadata } = await stores.pins.getWithMetadata(cid)
+  // @ts-ignore
+  return metadata
+}
+
+/**
+ * @param {string} cid CID of the pin
+ * @param {Pin} pin
+ * @returns {Promise<void>}
+ */
+export const set = async (cid, pin) => {
+  if (pin.status !== 'pinned' && pin.status !== 'failed') {
+    await Promise.all([
+      stores.pins.put(cid, '', { metadata: pin }),
+      stores.followups.put(cid, '', { metadata: pin }),
+    ])
+  } else {
+    await stores.pins.put(cid, '', { metadata: pin })
+  }
+}
+
+/**
+ * @returns {AsyncIterable<[string, Pin]>}
+ */
+export async function* entries() {
+  let done = false
+  let cursor
+  while (!done) {
+    // @ts-ignore
+    const list = await stores.pins.list({ cursor })
+    for (const k of list.keys) {
+      if (k == null) continue
+      yield [k.name, k.metadata]
+    }
+    cursor = list.cursor
+    done = list.list_complete
+  }
+}

--- a/site/src/models/pins.js
+++ b/site/src/models/pins.js
@@ -1,6 +1,6 @@
 import { stores } from '../constants.js'
 
-/** @typedef {{ status: import('../bindings.js').PinStatus, size: number, created: string }} Pin */
+/** @typedef {{ cid: string, status: import('../bindings.js').PinStatus, size: number, created: string }} Pin */
 
 /**
  * @param {string} cid CID of the pin

--- a/site/src/models/pins.js
+++ b/site/src/models/pins.js
@@ -13,6 +13,7 @@ export const get = async (cid) => {
 }
 
 /**
+ * Note: pin data is stored in KV metadata to allow quick iteration.
  * @param {string} cid CID of the pin
  * @param {Pin} pin
  * @returns {Promise<void>}

--- a/site/src/routes/metrics.js
+++ b/site/src/routes/metrics.js
@@ -19,24 +19,61 @@ async function exportPromMetrics() {
     '# HELP nftstorage_users_total Total users registered.',
     '# TYPE nftstorage_users_total counter',
     `nftstorage_users_total ${await getOr0('users:total')}`,
+
     '# HELP nftstorage_nfts_total Total number of NFTs stored.',
     '# TYPE nftstorage_nfts_total counter',
     `nftstorage_nfts_total ${await getOr0('nfts:total')}`,
+
     '# HELP nftstorage_nfts_bytes_total Total bytes of all NFTs.',
     '# TYPE nftstorage_nftstorage_nfts_bytes_total counter',
     `nftstorage_nfts_bytes_total ${await getOr0('nfts:totalBytes')}`,
+
     '# HELP nftstorage_nfts_storage_ipfs_total Total number of NFTs pinned on IPFS.',
     '# TYPE nftstorage_nfts_storage_ipfs_total counter',
     `nftstorage_nfts_storage_ipfs_total ${await getOr0('nfts:pins:total')}`,
+
     '# HELP nftstorage_nfts_storage_filecoin_total Total number of NFTs stored on Filecoin in active deals.',
     '# TYPE nftstorage_nfts_storage_filecoin_total counter',
     `nftstorage_nfts_storage_filecoin_total ${await getOr0(
       'nfts:deals:active:total'
     )}`,
+
     '# HELP nftstorage_nfts_storage_filecoin_queued_total Total number of NFTs queued for the next deal batch.',
     '# TYPE nftstorage_nfts_storage_filecoin_queued_total counter',
     `nftstorage_nfts_storage_filecoin_queued_total ${await getOr0(
       'nfts:deals:queued:total'
+    )}`,
+
+    '# HELP nftstorage_pins_total Total number of pins on IPFS.',
+    '# TYPE nftstorage_pins_total counter',
+    `nftstorage_pins_total ${await getOr0('pins:total')}`,
+
+    '# HELP nftstorage_pins_bytes_total Total size of pinned items on IPFS.',
+    '# TYPE nftstorage_pins_bytes_total counter',
+    `nftstorage_pins_bytes_total ${await getOr0('pins:totalBytes')}`,
+
+    '# HELP nftstorage_pins_status_queued_total Total number of pins that are queued.',
+    '# TYPE nftstorage_pins_status_queued_total counter',
+    `nftstorage_pins_status_queued_total ${await getOr0(
+      'pins:status:queued:total'
+    )}`,
+
+    '# HELP nftstorage_pins_status_pinning_total Total number of pins that are pinning.',
+    '# TYPE nftstorage_pins_status_pinning_total counter',
+    `nftstorage_pins_status_pinning_total ${await getOr0(
+      'pins:status:pinning:total'
+    )}`,
+
+    '# HELP nftstorage_pins_status_pinned_total Total number of pins that are pinned.',
+    '# TYPE nftstorage_pins_status_pinned_total counter',
+    `nftstorage_pins_status_pinned_total ${await getOr0(
+      'pins:status:pinned:total'
+    )}`,
+
+    '# HELP nftstorage_pins_status_failed_total Total number of pins that are failed.',
+    '# TYPE nftstorage_pins_status_failed_total counter',
+    `nftstorage_pins_status_failed_total ${await getOr0(
+      'pins:status:failed:total'
     )}`,
   ].join('\n')
 }

--- a/site/src/routes/nfts-get.js
+++ b/site/src/routes/nfts-get.js
@@ -2,6 +2,7 @@ import { HTTPError } from '../errors.js'
 import { get as getNft } from '../models/nfts.js'
 import { JSONResponse } from '../utils/json-response.js'
 import { get as getDeals } from '../models/deals.js'
+import { get as getPin } from '../models/pins.js'
 import { validate } from '../utils/auth.js'
 
 /**
@@ -16,14 +17,22 @@ export const status = async (event, params) => {
   const auth = await validate(event)
   const user = auth.user
 
-  const [nft, deals] = await Promise.all([
+  const [nft, pin, deals] = await Promise.all([
     getNft({ user, cid: params.cid }),
+    getPin(params.cid),
     getDeals(params.cid),
   ])
 
   if (nft == null) {
-    return HTTPError.respond(new HTTPError('not found', 404))
+    return HTTPError.respond(new HTTPError('NFT not found', 404))
   }
 
-  return new JSONResponse({ ok: true, value: { ...nft, deals } })
+  if (pin == null) {
+    return HTTPError.respond(new HTTPError('pin not found', 404))
+  }
+
+  return new JSONResponse({
+    ok: true,
+    value: { ...nft, size: pin.size, pin, deals },
+  })
 }

--- a/site/src/routes/nfts-get.js
+++ b/site/src/routes/nfts-get.js
@@ -31,13 +31,13 @@ export const status = async (event, params) => {
     return HTTPError.respond(new HTTPError('pin not found', 404))
   }
 
-  return new JSONResponse({
-    ok: true,
-    value: {
-      ...nft,
-      size: pin.size,
-      pin: { ...(nft.pin || {}), ...pin },
-      deals,
-    },
-  })
+  /** @type {import('../bindings').NFTResponse} */
+  const res = {
+    ...nft,
+    size: pin.size,
+    pin: { cid: nft.cid, ...(nft.pin || {}), ...pin },
+    deals,
+  }
+
+  return new JSONResponse({ ok: true, value: res })
 }

--- a/site/src/routes/nfts-get.js
+++ b/site/src/routes/nfts-get.js
@@ -33,6 +33,11 @@ export const status = async (event, params) => {
 
   return new JSONResponse({
     ok: true,
-    value: { ...nft, size: pin.size, pin, deals },
+    value: {
+      ...nft,
+      size: pin.size,
+      pin: { ...(nft.pin || {}), ...pin },
+      deals,
+    },
   })
 }

--- a/site/src/routes/nfts-get.js
+++ b/site/src/routes/nfts-get.js
@@ -35,7 +35,7 @@ export const status = async (event, params) => {
   const res = {
     ...nft,
     size: pin.size,
-    pin: { cid: nft.cid, ...(nft.pin || {}), ...pin },
+    pin: { ...(nft.pin || {}), ...pin },
     deals,
   }
 

--- a/site/src/routes/nfts-upload.js
+++ b/site/src/routes/nfts-upload.js
@@ -42,7 +42,6 @@ export async function upload(event) {
         type: f.type,
       })),
     }
-    // @ts-ignore
     nftSize = size
   } else {
     const blob = await event.request.blob()
@@ -57,7 +56,6 @@ export async function upload(event) {
       scope: tokenName,
       files: [],
     }
-    // @ts-ignore
     nftSize = size
   }
 

--- a/site/src/routes/nfts-upload.js
+++ b/site/src/routes/nfts-upload.js
@@ -63,19 +63,14 @@ export async function upload(event) {
 
   let pin = await pins.get(nft.cid)
   if (!pin || pin.status !== 'pinned') {
-    pin = { status: 'pinned', size: nftSize, created }
+    pin = { cid: nft.cid, status: 'pinned', size: nftSize, created }
     await pins.set(nft.cid, pin)
   }
 
   await nfts.set({ user, cid: nft.cid }, nft, pin)
 
   /** @type {import('../bindings').NFTResponse} */
-  const res = {
-    ...nft,
-    size: pin.size,
-    pin: { cid: nft.cid, ...pin },
-    deals: [],
-  }
+  const res = { ...nft, size: pin.size, pin, deals: [] }
 
   event.waitUntil(
     (async () => {

--- a/site/src/routes/nfts-upload.js
+++ b/site/src/routes/nfts-upload.js
@@ -19,6 +19,11 @@ export async function upload(event) {
   const contentType = headers.get('content-type') || ''
   const { user, tokenName } = await validate(event)
 
+  /** @type {NFT} */
+  let nft
+  let nftSize = 0
+  const created = new Date().toISOString()
+
   if (contentType.includes('multipart/form-data')) {
     const form = await toFormData(event.request)
     // Our API schema requires that all file parts be named `file` and
@@ -27,23 +32,9 @@ export async function upload(event) {
     const files = /** @type {File[]} */ (form.getAll('file'))
     const dir = await cluster.addDirectory(files)
     const { cid, size } = dir[dir.length - 1]
-    event.waitUntil(
-      (async () => {
-        try {
-          await pinata.pinByHash(cid, {
-            pinataOptions: { hostNodes: cluster.delegates() },
-            pinataMetadata: { name: `${user.nickname}-${Date.now()}` },
-          })
-        } catch (err) {
-          console.error(err)
-        }
-      })()
-    )
-    const created = new Date()
-    /** @type {NFT} */
-    const nft = {
+    nft = {
       cid,
-      created: created.toISOString(),
+      created,
       type: 'directory',
       scope: tokenName,
       files: files.map((f) => ({
@@ -51,57 +42,53 @@ export async function upload(event) {
         type: f.type,
       })),
     }
-    let pin = await pins.get(cid)
-    if (!pin || pin.status !== 'pinned') {
-      // @ts-ignore
-      pin = { status: 'pinned', size, created: created.toISOString() }
-      await pins.set(cid, pin)
-    }
-    const result = await nfts.set({ user, cid }, nft)
-    return new JSONResponse({
-      ok: true,
-      value: { ...result, size, pin, deals: [] },
-    })
+    // @ts-ignore
+    nftSize = size
   } else {
     const blob = await event.request.blob()
     if (blob.size === 0) {
-      return HTTPError.respond(new HTTPError('Empty payload', 400))
+      throw new HTTPError('Empty payload', 400)
     }
     const { cid, size } = await cluster.add(blob)
-    event.waitUntil(
-      (async () => {
-        try {
-          await pinata.pinByHash(cid, {
-            pinataOptions: { hostNodes: cluster.delegates() },
-            pinataMetadata: { name: `${user.nickname}-${Date.now()}` },
-          })
-        } catch (err) {
-          console.error(err)
-        }
-      })()
-    )
-    const created = new Date()
-    /** @type {NFT} */
-    const nft = {
+    nft = {
       cid,
-      created: created.toISOString(),
+      created,
       type: blob.type,
       scope: tokenName,
       files: [],
     }
-    let pin = await pins.get(cid)
-    if (!pin || pin.status !== 'pinned') {
-      pin = {
-        status: 'pinned',
-        size: blob.size,
-        created: created.toISOString(),
-      }
-      await pins.set(cid, pin)
-    }
-    const result = await nfts.set({ user, cid }, nft)
-    return new JSONResponse({
-      ok: true,
-      value: { ...result, size: blob.size, pin, deals: [] },
-    })
+    // @ts-ignore
+    nftSize = size
   }
+
+  let pin = await pins.get(nft.cid)
+  if (!pin || pin.status !== 'pinned') {
+    pin = { status: 'pinned', size: nftSize, created }
+    await pins.set(nft.cid, pin)
+  }
+
+  await nfts.set({ user, cid: nft.cid }, nft, pin)
+
+  /** @type {import('../bindings').NFTResponse} */
+  const res = {
+    ...nft,
+    size: pin.size,
+    pin: { cid: nft.cid, ...pin },
+    deals: [],
+  }
+
+  event.waitUntil(
+    (async () => {
+      try {
+        await pinata.pinByHash(nft.cid, {
+          pinataOptions: { hostNodes: cluster.delegates() },
+          pinataMetadata: { name: `${user.nickname}-${Date.now()}` },
+        })
+      } catch (err) {
+        console.error(err)
+      }
+    })()
+  )
+
+  return new JSONResponse({ ok: true, value: res })
 }

--- a/site/src/routes/pins-add.js
+++ b/site/src/routes/pins-add.js
@@ -1,6 +1,7 @@
 import * as PinataPSA from '../pinata-psa.js'
 import { JSONResponse } from '../utils/json-response.js'
 import * as nfts from '../models/nfts.js'
+import * as pins from '../models/pins.js'
 import * as cluster from '../cluster.js'
 import { validate } from '../utils/auth.js'
 
@@ -41,33 +42,17 @@ export async function pinsAdd(event) {
     )
   }
 
-  /** @type import('@nftstorage/ipfs-cluster').PinResponse | undefined */
-  let pin
-  /** @type import('../pinata-psa').Status */
-  let status = 'pinning'
-  let size = 0
-  try {
-    pin = await cluster.allocation(pinData.cid)
-  } catch (err) {
-    // if 404 we can continue, we have not pinned this CID
-    if (!err.response || err.response.status !== 404) {
-      throw err
-    }
-  }
-
+  const created = new Date().toISOString()
+  const pin = await pins.get(pinData.cid)
   if (pin) {
-    // if we cached the size then use it
-    if (pin.metadata && pin.metadata.size) {
-      size = parseInt(pin.metadata.size)
-    }
-    // we have this pin already allocated in our cluster, get the status...
-    status = cluster.toPSAStatus(await cluster.status(pin.cid))
     // if this failed to pin, try again
-    if (status === 'failed') {
+    if (pin.status === 'failed') {
       await cluster.recover(pinData.cid)
+      pin.status = 'queued'
     }
   } else {
-    pin = await cluster.pin(pinData.cid)
+    await cluster.pin(pinData.cid)
+    await pins.set(pinData.cid, { status: 'queued', size: 0, created })
   }
 
   event.waitUntil(
@@ -80,39 +65,23 @@ export async function pinsAdd(event) {
     })()
   )
 
-  const created = new Date()
   /** @type import('../bindings').NFT */
   const nft = {
-    cid: pin.cid,
-    size,
-    created: created.toISOString(),
+    cid: pinData.cid,
+    created,
     type: 'remote',
     scope: tokenName,
     files: [],
-    pin: {
-      cid: pin.cid,
-      name,
-      meta,
-      size,
-      status,
-      created: created.toISOString(),
-    },
+    pin: { name, meta },
   }
-  const metadata = {
-    name,
-    meta,
-    pinStatus: status,
-    size,
-    created: created.toISOString(),
-  }
-  await nfts.set({ user, cid: pin.cid }, nft, { metadata })
+  await nfts.set({ user, cid: pinData.cid }, nft)
 
   /** @type import('../pinata-psa').PinStatus */
   const pinStatus = {
-    requestid: pin.cid,
-    status,
-    created: created.toISOString(),
-    pin: { cid: pin.cid, name, meta },
+    requestid: pinData.cid,
+    status: 'queued',
+    created,
+    pin: { cid: pinData.cid, name, meta },
     delegates: cluster.delegates(),
   }
   return new JSONResponse(pinStatus)

--- a/site/src/routes/pins-add.js
+++ b/site/src/routes/pins-add.js
@@ -80,7 +80,7 @@ export async function pinsAdd(event) {
     files: [],
     pin: { name, meta },
   }
-  await nfts.set({ user, cid: pinData.cid }, nft)
+  await nfts.set({ user, cid: pinData.cid }, nft, pin)
 
   /** @type import('../pinata-psa').PinStatus */
   const pinStatus = {

--- a/site/src/routes/pins-add.js
+++ b/site/src/routes/pins-add.js
@@ -53,7 +53,7 @@ export async function pinsAdd(event) {
     }
   } else {
     await cluster.pin(pinData.cid)
-    pin = { status: 'queued', size: 0, created }
+    pin = { cid: pinData.cid, status: 'queued', size: 0, created }
     await pins.set(pinData.cid, pin)
   }
 
@@ -84,10 +84,10 @@ export async function pinsAdd(event) {
 
   /** @type import('../pinata-psa').PinStatus */
   const pinStatus = {
-    requestid: pinData.cid,
+    requestid: pin.cid,
     status: pin.status,
     created: pin.created,
-    pin: { cid: pinData.cid, name, meta },
+    pin: { cid: pin.cid, name, meta },
     delegates: cluster.delegates(),
   }
   return new JSONResponse(pinStatus)

--- a/site/src/routes/pins-delete.js
+++ b/site/src/routes/pins-delete.js
@@ -25,7 +25,7 @@ export async function pinsDelete(event, params) {
 
   if (!nft) {
     return new JSONResponse(
-      { error: { reason: 'NOT_FOUND', details: 'pin not found' } },
+      { error: { reason: 'NOT_FOUND', details: 'NFT not found' } },
       { status: 404 }
     )
   }

--- a/site/src/routes/pins-get.js
+++ b/site/src/routes/pins-get.js
@@ -2,6 +2,7 @@ import * as PinataPSA from '../pinata-psa.js'
 import { validate } from '../utils/auth.js'
 import { JSONResponse } from '../utils/json-response.js'
 import * as nfts from '../models/nfts.js'
+import * as pins from '../models/pins.js'
 import * as cluster from '../cluster.js'
 
 /**
@@ -27,6 +28,14 @@ export async function pinsGet(event, params) {
 
   if (!nft) {
     return new JSONResponse(
+      { error: { reason: 'NOT_FOUND', details: 'NFT not found' } },
+      { status: 404 }
+    )
+  }
+
+  const pin = await pins.get(cid)
+  if (!nft) {
+    return new JSONResponse(
       { error: { reason: 'NOT_FOUND', details: 'pin not found' } },
       { status: 404 }
     )
@@ -35,9 +44,9 @@ export async function pinsGet(event, params) {
   /** @type import('../pinata-psa').PinStatus */
   const pinStatus = {
     requestid: nft.cid,
-    status: nft.pin.status,
+    status: pin.status,
     created: nft.created,
-    pin: { cid: nft.cid, name: nft.pin.name, meta: nft.pin.meta },
+    pin: { cid: nft.cid, ...(nft.pin || {}) },
     delegates: cluster.delegates(),
   }
 

--- a/site/src/routes/pins-list.js
+++ b/site/src/routes/pins-list.js
@@ -140,10 +140,7 @@ function makeFilter(options) {
         }
       }
     }
-    if (
-      options.status &&
-      (data.pinStatus == null || !options.status.includes(data.pinStatus))
-    ) {
+    if (options.status && !options.status.includes(data.pinStatus)) {
       return false
     }
     if (options.before || options.after) {

--- a/site/src/routes/pins-replace.js
+++ b/site/src/routes/pins-replace.js
@@ -112,7 +112,7 @@ export async function pinsReplace(event, params) {
     pin: { name, meta },
   }
   await Promise.all([
-    nfts.set({ user, cid: pinData.cid }, nft),
+    nfts.set({ user, cid: pinData.cid }, nft, pin),
     nfts.remove({ user, cid: existingCID }),
   ])
 

--- a/site/src/routes/pins-replace.js
+++ b/site/src/routes/pins-replace.js
@@ -84,7 +84,7 @@ export async function pinsReplace(event, params) {
     }
   } else {
     await cluster.pin(pinData.cid)
-    pin = { status: 'queued', size: 0, created }
+    pin = { cid: pinData.cid, status: 'queued', size: 0, created }
     await pins.set(pinData.cid, pin)
   }
 
@@ -118,10 +118,10 @@ export async function pinsReplace(event, params) {
 
   /** @type import('../pinata-psa').PinStatus */
   const pinStatus = {
-    requestid: pinData.cid,
+    requestid: pin.cid,
     status: pin.status,
     created: pin.created,
-    pin: { cid: pinData.cid, name, meta },
+    pin: { cid: pin.cid, name, meta },
     delegates: cluster.delegates(),
   }
   return new JSONResponse(pinStatus)

--- a/site/wrangler.toml
+++ b/site/wrangler.toml
@@ -54,5 +54,6 @@ kv_namespaces = [
     { binding = "NFTS", preview_id = "c8fd3b56aa284e1395169c681a04fc91", id = "c8fd3b56aa284e1395169c681a04fc91" },
     { binding = "NFTS_IDX", preview_id = "59c33b953d40498a91f7b4ba5a747c24", id = "59c33b953d40498a91f7b4ba5a747c24" },
     { binding = "DEALS", preview_id = "e8bdcf6793554671ba98cfc7eaf4a225", id = "e8bdcf6793554671ba98cfc7eaf4a225" },
-    { binding = "METRICS", preview_id = "9f28491818d742a2b1363449fe39d6b7", id = "9f28491818d742a2b1363449fe39d6b7" }
+    { binding = "METRICS", preview_id = "9f28491818d742a2b1363449fe39d6b7", id = "9f28491818d742a2b1363449fe39d6b7" },
+    { binding = "PINS", preview_id = "21a950c30fe64f4c97f4257c8f4b45ae", id = "21a950c30fe64f4c97f4257c8f4b45ae" },
 ]

--- a/site/wrangler.toml
+++ b/site/wrangler.toml
@@ -8,7 +8,9 @@ kv_namespaces = [
     { binding = "NFTS", preview_id = "f1c35cd1601c452782db6056b2d35f25", id = "f1c35cd1601c452782db6056b2d35f25" },
     { binding = "NFTS_IDX", preview_id = "82122c8f826c4ffd90608007c8c0c8ad", id = "82122c8f826c4ffd90608007c8c0c8ad" },
     { binding = "DEALS", preview_id = "ce934a65bf6a44a398980a89daf66a70", id = "ce934a65bf6a44a398980a89daf66a70" },
-    { binding = "METRICS", preview_id = "104469a46696435bb2e7bfa201a36611", id = "104469a46696435bb2e7bfa201a36611" }
+    { binding = "METRICS", preview_id = "104469a46696435bb2e7bfa201a36611", id = "104469a46696435bb2e7bfa201a36611" },
+    { binding = "PINS", preview_id = "ccee8222a526468a9101ec8d09ea1158", id = "ccee8222a526468a9101ec8d09ea1158" },
+    { binding = "FOLLOWUPS", preview_id = "19ccf11bc39a43439d4de3e101c2a114", id = "19ccf11bc39a43439d4de3e101c2a114" }
 ]
 vars = { ENV = "dev", DEBUG = "*", CLUSTER_API_URL = "https://nft.storage.ipfscluster.io/api/", CLUSTER_IPFS_PROXY_API_URL = "https://nft.storage.ipfscluster.io/api/", CLUSTER_ADDRS = "/dns4/nft-storage-am6.nft.dwebops.net/tcp/18402/p2p/12D3KooWCRscMgHgEo3ojm8ovzheydpvTEqsDtq7Vby38cMHrYjt,/dns4/nft-storage-dc13.nft.dwebops.net/tcp/18402/p2p/12D3KooWQtpvNvUYFzAo1cRYkydgk15JrMSHp6B6oujqgYSnvsVm,/dns4/nft-storage-sv15.nft.dwebops.net/tcp/18402/p2p/12D3KooWQcgCwNCTYkyLXXQSZuL5ry1TzpM8PRe9dKddfsk1BxXZ" }
 
@@ -25,7 +27,9 @@ kv_namespaces = [
     { binding = "NFTS", preview_id = "21763d3a9ce2465b875a49ae57a5a598", id = "21763d3a9ce2465b875a49ae57a5a598" },
     { binding = "NFTS_IDX", preview_id = "4d25963cfab14d998d6e08d7ad336f83", id = "4d25963cfab14d998d6e08d7ad336f83" },
     { binding = "DEALS", preview_id = "ab1ee988b16747149e4dee6b1a07bbd2", id = "ab1ee988b16747149e4dee6b1a07bbd2" },
-    { binding = "METRICS", preview_id = "f80cad90abdf4bf98b41518f1e7a6ea1", id = "f80cad90abdf4bf98b41518f1e7a6ea1" }
+    { binding = "METRICS", preview_id = "f80cad90abdf4bf98b41518f1e7a6ea1", id = "f80cad90abdf4bf98b41518f1e7a6ea1" },
+    { binding = "PINS", preview_id = "39151b1207114d4d8bbd0b556079c76c", id = "ccee8222a526468a9101ec8d09ea1158" },
+    { binding = "FOLLOWUPS", preview_id = "e01b79aecb3e4d7db9473030e0714a23", id = "19ccf11bc39a43439d4de3e101c2a114" }
 ]
 
 [env.production]
@@ -38,7 +42,9 @@ kv_namespaces = [
     { binding = "NFTS", id = "9610798d5e5845fa94e4392cc1288ddf", preview_id = "f1c35cd1601c452782db6056b2d35f25" },
     { binding = "NFTS_IDX", id = "289648236dd74a8e96e5ee4f6581bff9", preview_id = "82122c8f826c4ffd90608007c8c0c8ad" },
     { binding = "DEALS", id = "9d5815757b04446ab8cfbc99e6296842", preview_id = "ce934a65bf6a44a398980a89daf66a70" },
-    { binding = "METRICS", id = "12c38488fd6047fd8bb4030a8dacb406", preview_id = "104469a46696435bb2e7bfa201a36611" }
+    { binding = "METRICS", id = "12c38488fd6047fd8bb4030a8dacb406", preview_id = "104469a46696435bb2e7bfa201a36611" },
+    { binding = "PINS", id = "fd42ed10e9ce4b27aa77ca7b862dd2d8", preview_id = "ccee8222a526468a9101ec8d09ea1158" },
+    { binding = "FOLLOWUPS", id = "e6f35158a06646478f382847f2c40942", preview_id = "19ccf11bc39a43439d4de3e101c2a114" }
 ]
 
 [env.alanshaw]
@@ -56,4 +62,5 @@ kv_namespaces = [
     { binding = "DEALS", preview_id = "e8bdcf6793554671ba98cfc7eaf4a225", id = "e8bdcf6793554671ba98cfc7eaf4a225" },
     { binding = "METRICS", preview_id = "9f28491818d742a2b1363449fe39d6b7", id = "9f28491818d742a2b1363449fe39d6b7" },
     { binding = "PINS", preview_id = "21a950c30fe64f4c97f4257c8f4b45ae", id = "21a950c30fe64f4c97f4257c8f4b45ae" },
+    { binding = "FOLLOWUPS", preview_id = "50c7fad96e6f403aaf9527e12adf42b7", id = "50c7fad96e6f403aaf9527e12adf42b7" }
 ]

--- a/website/public/schema.yml
+++ b/website/public/schema.yml
@@ -308,6 +308,8 @@ components:
         name:
           type: string
           example: pin name
+        meta:
+          type: object
         status:
           $ref: '#/components/schemas/PinStatus'
         created:
@@ -354,10 +356,7 @@ components:
             cid:
               $ref: '#/components/schemas/CID'
             pin:
-              type: object
-              properties:
-                status:
-                  $ref: '#/components/schemas/PinStatus'
+              $ref: '#/components/schemas/Pin'
             deals:
               type: array
               items:


### PR DESCRIPTION
# Problems:

1. We currently have a cron job that updates pin status and size for every NFT. It has to crawl every single NFT in the table and eventually it will be too big and hit API limits.
2. Every call to `/check/{cid}` results in a call to IPFS Cluster.
3. Our total data size metric is incorrect because it double counts two NFTs that have uploaded the same content.
4. Pinning Services API pins listing very inefficiently crawls the unordered list of NFTS for a given user and orders them on the  fly.

# Solutions:

1. We store every pin that needs to be followed up on in a separate KV so we only need to iterate over pins that need to be followed up on and remove the ones that are done.
2. We store pins (their size and status) in a separate KV store that can be easily queried by CID and do not have to talk to IPFS Cluster.
3. The separate KV store for pins keyed by CID means we won't double count when two NFTs are pinning the same file.
4. The metadata previously stored in the NFTS KV store has moved to the NFTS_IDX store. NFTS_IDX is date ordered per user so allows for significantly more efficient listing of NFT data.

## Additions in this PR

* Two new KV namespaces: PINS and FOLLOWUPS

    **PINS**: CIDs that are pending or pinned to the cluster
    key: `cid`
    value: `empty`
    metadata: `{ status: PinStatus, size: number, created: string }`

    **FOLLOWUPS**: CIDs that are being pinned to the cluster that need to be re-checked for completion/failure
    key: `cid`
    value: `empty`
    metadata: `{ status: PinStatus, size: number, created: string }`

* Migrations to populate these new KVs.

* New cron job to process items in the **FOLLOWUPS** KV

* New cron job to keep **NFTS_IDX** metadata up to date

## Changes in this PR

* Records in the **NFTS** KV no longer have a `size` property and their `pin` property is optional and may only contain optional `name: string` and `meta: Record<string, string>` values. When returning an NFT from the API we "inflate" the `size` and `pin` properties by fetching the data from **PINS**.

* Creating a new pin will cause a record to be added to **FOLLOWUPS** if the CID has not already been pinned.

* Records in the **NFTS** KV no longer have metadata - it has moved to **NFTS_IDX**.

* The Pinning Services API pin listing (`GET /pins`) now uses **NFTS_IDX**.

