### PR TITLE
test: site tests

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -10,7 +10,9 @@
     "lt:ipfs-proxy": "npx localtunnel --port 9095 --subdomain \"$(whoami)-ipfs-proxy-api-nft-storage\"",
     "deploy": "wrangler publish --env production",
     "dev": "wrangler dev",
-    "test": "tsc"
+    "test": "npm run test:ts && npm run test:e2e",
+    "test:ts": "tsc",
+    "test:e2e": "playwright-test \"test/**/*.spec.js\" --mode worker"
   },
   "author": "Hugo Dias <hugomrdias@gmail.com> (hugodias.me)",
   "license": "MIT",
@@ -32,8 +34,14 @@
     "@magic-ext/oauth": "^0.7.0",
     "@sentry/webpack-plugin": "^1.15.1",
     "@types/debug": "^4.1.5",
+    "@types/mocha": "^8.2.2",
+    "buffer": "^6.0.3",
+    "cf-workers-memkv": "^1.0.2",
     "dotenv": "^8.2.0",
     "git-revision-webpack-plugin": "^3.0.6",
+    "playwright-test": "^3.0.7",
+    "process": "^0.11.10",
+    "readable-stream": "^3.6.0",
     "webpack": "^4.0.0"
   }
 }

--- a/site/pw-test.config.js
+++ b/site/pw-test.config.js
@@ -1,0 +1,20 @@
+const path = require('path')
+
+module.exports = {
+  buildConfig: {
+    inject: [
+      path.join(__dirname, './test/scripts/node-globals.js'),
+      path.join(__dirname, './test/scripts/worker-globals.js'),
+    ],
+    plugins: [
+      {
+        name: 'node builtins',
+        setup(build) {
+          build.onResolve({ filter: /^stream$/ }, () => {
+            return { path: require.resolve('readable-stream') }
+          })
+        },
+      },
+    ],
+  },
+}

--- a/site/src/bindings.d.ts
+++ b/site/src/bindings.d.ts
@@ -13,6 +13,8 @@ declare global {
   const METRICS: KVNamespace
   const PINS: KVNamespace
   const FOLLOWUPS: KVNamespace
+  const PINATA_API_URL: string
+  const PINATA_PSA_API_URL: string
   const PINATA_JWT: string
   const CLUSTER_API_URL: string
   const CLUSTER_BASIC_AUTH_TOKEN: string

--- a/site/src/constants.js
+++ b/site/src/constants.js
@@ -30,4 +30,15 @@ export const cluster = {
   addrs: Object.freeze(CLUSTER_ADDRS.split(',').filter(Boolean)),
 }
 
+export const pinata = {
+  apiUrl:
+    typeof PINATA_API_URL !== 'undefined'
+      ? PINATA_API_URL
+      : 'https://api.pinata.cloud',
+  psaApiUrl:
+    typeof PINATA_PSA_API_URL !== 'undefined'
+      ? PINATA_PSA_API_URL
+      : 'https://api.pinata.cloud/psa/',
+}
+
 export const isDebug = DEBUG === 'true'

--- a/site/src/pinata-psa.js
+++ b/site/src/pinata-psa.js
@@ -1,7 +1,7 @@
-import { secrets } from './constants.js'
+import { pinata, secrets } from './constants.js'
 import { JSONResponse } from './utils/json-response.js'
 
-const endpoint = new URL('https://api.pinata.cloud/psa/')
+const endpoint = new URL(pinata.psaApiUrl)
 const headers = {
   authorization: `Bearer ${secrets.pinata}`,
   'Content-Type': 'application/json',

--- a/site/src/pinata.js
+++ b/site/src/pinata.js
@@ -1,6 +1,4 @@
-import { secrets } from './constants.js'
-
-const endpoint = new URL('https://api.pinata.cloud')
+import { pinata, secrets } from './constants.js'
 
 /**
  * @typedef {import('./models/users.js').User} User
@@ -34,7 +32,7 @@ export const pinFile = async (blob, user) => {
       },
     })
   )
-  const url = new URL('/pinning/pinFileToIPFS', endpoint)
+  const url = new URL('/pinning/pinFileToIPFS', pinata.apiUrl)
 
   const response = await fetch(url.toString(), {
     body,
@@ -84,7 +82,7 @@ export async function pinFiles(files, user) {
       },
     })
   )
-  const url = new URL('/pinning/pinFileToIPFS', endpoint)
+  const url = new URL('/pinning/pinFileToIPFS', pinata.apiUrl)
 
   const response = await fetch(url.toString(), {
     body,
@@ -108,7 +106,7 @@ export async function pinFiles(files, user) {
 export const pinInfo = async (cid) => {
   const url = new URL(
     `/data/pinList?status=pinned&hashContains=${encodeURIComponent(cid)}`,
-    endpoint
+    pinata.apiUrl
   )
 
   const response = await fetch(url.toString(), {
@@ -132,7 +130,7 @@ export const pinInfo = async (cid) => {
  * @returns {Promise<{ ok: true, value: { id: string, ipfsHash: string, status: string, name: string} }|{ ok: false, error: Response }>}
  */
 export async function pinByHash(cid, options) {
-  const url = new URL('/pinning/pinByHash', endpoint)
+  const url = new URL('/pinning/pinByHash', pinata.apiUrl)
 
   const response = await fetch(url.toString(), {
     method: 'POST',

--- a/site/test/nfts-check.spec.js
+++ b/site/test/nfts-check.spec.js
@@ -1,0 +1,49 @@
+import assert from 'assert'
+import '../src/index.js'
+import { TestFetchEvent } from './scripts/events.js'
+import { set as setPin } from '../src/models/pins.js'
+import { clearStores } from './scripts/helpers.js'
+
+const cid = 'Qmf412jQZiuVUtdgnB36FXFX7xg5V6KEbSJ4dpQuhkLyfD'
+
+describe('/check/{cid}', () => {
+  beforeEach(clearStores)
+
+  it('should retrieve pin and deal information for CID', async () => {
+    /** @type {import('../src/models/pins.js').Pin} */
+    const pin = {
+      cid,
+      status: 'pinned',
+      size: 1234,
+      created: new Date().toISOString(),
+    }
+    await setPin(cid, pin)
+
+    /** @type {import('../src/bindings').Deal[]} */
+    const deals = [{ status: 'queued', lastChanged: new Date() }]
+    await DEALS.put(cid, JSON.stringify(deals))
+
+    const request = new Request(`http://localhost/check/${cid}`)
+    const event = new TestFetchEvent('fetch', { request })
+    globalThis.dispatchEvent(event)
+    const res = await event.respondWithPromise
+    assert(res)
+    assert(res.ok)
+    const { ok, value } = await res.json()
+    assert(ok)
+    assert.deepStrictEqual(value.pin, pin)
+    assert.deepStrictEqual(value.deals, JSON.parse(JSON.stringify(deals)))
+  })
+
+  it('should error if CID is not found', async () => {
+    const request = new Request(`http://localhost/check/${cid}`)
+    const event = new TestFetchEvent('fetch', { request })
+    globalThis.dispatchEvent(event)
+    const res = await event.respondWithPromise
+    assert(res)
+    assert.strictEqual(res.status, 404)
+    const { ok, error } = await res.json()
+    assert(!ok)
+    assert.strictEqual(error.message, 'NFT not found')
+  })
+})

--- a/site/test/scripts/events.js
+++ b/site/test/scripts/events.js
@@ -1,0 +1,43 @@
+/**
+ * A service worker FetchEvent mock.
+ * Necessary until playwright supports service workers.
+ */
+class FetchEvent extends CustomEvent {
+  /**
+   * @param {string} type
+   * @param {{ request: Request }} init
+   */
+  constructor(type, init) {
+    super(type)
+    this.request = init.request
+  }
+  /**
+   * @param {Promise<any>} _promise
+   */
+  waitUntil(_promise) {}
+  /**
+   * @param {Promise<Response>} _promise
+   */
+  respondWith(_promise) {}
+}
+
+/**
+ * A FetchEvent that exposes the promises set using respondWith and waitUntil
+ * as class properties.
+ */
+export class TestFetchEvent extends FetchEvent {
+  /**
+   * @param {Promise<any>} promise
+   */
+  waitUntil(promise) {
+    super.waitUntil(promise)
+    this.waitUntilPromise = promise
+  }
+  /**
+   * @param {Promise<Response>} promise
+   */
+  respondWith(promise) {
+    super.respondWith(promise)
+    this.respondWithPromise = promise
+  }
+}

--- a/site/test/scripts/helpers.js
+++ b/site/test/scripts/helpers.js
@@ -1,0 +1,20 @@
+import { stores } from '../../src/constants.js'
+
+export async function clearStores() {
+  for (const store of Object.values(stores)) {
+    /** @type {string[]} */
+    const keys = []
+    let cursor, done
+    while (!done) {
+      // @ts-ignore
+      const list = await store.list({ cursor })
+      // @ts-ignore
+      keys.push(...list.keys.map((k) => k.name))
+      cursor = list.cursor
+      done = list.list_complete
+    }
+    for (const k of keys) {
+      await store.delete(k)
+    }
+  }
+}

--- a/site/test/scripts/node-globals.js
+++ b/site/test/scripts/node-globals.js
@@ -1,0 +1,3 @@
+// @ts-nocheck
+export const { Buffer } = require('buffer')
+export const process = require('process/browser')

--- a/site/test/scripts/worker-globals.js
+++ b/site/test/scripts/worker-globals.js
@@ -1,0 +1,23 @@
+import { MemKV } from 'cf-workers-memkv'
+
+export const SALT = Math.random().toString()
+export const DEBUG = 'true'
+export const DEALS = new MemKV()
+export const USERS = new MemKV()
+export const NFTS = new MemKV()
+export const NFTS_IDX = new MemKV()
+export const METRICS = new MemKV()
+export const PINS = new MemKV()
+export const FOLLOWUPS = new MemKV()
+export const PINATA_JWT = 'test'
+export const CLUSTER_API_URL = 'http://localhost:9094'
+export const CLUSTER_BASIC_AUTH_TOKEN = 'test'
+export const CLUSTER_IPFS_PROXY_API_URL = 'http://localhost:9095'
+export const CLUSTER_IPFS_PROXY_BASIC_AUTH_TOKEN = 'test'
+export const CLUSTER_ADDRS = ''
+export const MAGIC_SECRET_KEY = 'test'
+export const ENV = 'test'
+export const SENTRY_DSN = 'https://test@test.ingest.sentry.io/0000000'
+export const BRANCH = 'test'
+export const VERSION = 'test'
+export const COMMITHASH = 'test'

--- a/site/test/version.spec.js
+++ b/site/test/version.spec.js
@@ -1,0 +1,18 @@
+import assert from 'assert'
+import '../src/index.js'
+import { TestFetchEvent } from './scripts/events.js'
+
+describe('/version', () => {
+  it('should get version information', async () => {
+    const request = new Request('http://localhost/version')
+    const event = new TestFetchEvent('fetch', { request })
+    globalThis.dispatchEvent(event)
+    const res = await event.respondWithPromise
+    assert(res)
+    assert(res.ok)
+    const { version, commit, branch } = await res.json()
+    assert.strictEqual(version, VERSION)
+    assert.strictEqual(commit, COMMITHASH)
+    assert.strictEqual(branch, BRANCH)
+  })
+})

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -15,12 +15,13 @@
     "skipLibCheck": true,
     "noEmit": true,
     "resolveJsonModule": true,
-    "types": ["@cloudflare/workers-types"]
+    "types": ["@cloudflare/workers-types", "mocha"]
   },
   "include": [
     "src",
     "src/bindings.d.ts",
-    "node_modules/@cloudflare/workers-types/index.d.ts"
+    "node_modules/@cloudflare/workers-types/index.d.ts",
+    "test"
   ],
   "exclude": ["node_modules/", "dist/", "src/utils/multipart/**/*.js"]
 }


### PR DESCRIPTION
Adds e2e tests for the API, using playwright.

Eventually the following repeated lines in tests will be replaced:

```js
    const request = new Request(`http://localhost/check/${cid}`)
    const event = new TestFetchEvent('fetch', { request })
    globalThis.dispatchEvent(event)
    const res = await event.respondWithPromise
```

...with a call to `fetch` when playwright supports service workers (currently only regular workers):

```js
    const res = await fetch(`http://localhost/check/${cid}`)
```

Later, these same tests can be run against a real life deployed API on Cloudflare.

resolves #96 