### PR TITLE
revert: collection of followup metrics

### DIFF
--- a/packages/api/src/routes/metrics.js
+++ b/packages/api/src/routes/metrics.js
@@ -75,9 +75,5 @@ async function exportPromMetrics() {
     `nftstorage_pins_status_failed_total ${await getOr0(
       'pins:status:failed:total'
     )}`,
-
-    '# HELP nftstorage_followups_total Total number of pins that are being followed until pinned or failed.',
-    '# TYPE nftstorage_followups_total counter',
-    `nftstorage_followups_total ${await getOr0('followups:total')}`,
   ].join('\n')
 }

--- a/packages/cron/src/bin/metrics.js
+++ b/packages/cron/src/bin/metrics.js
@@ -15,7 +15,6 @@ async function main() {
     metrics.updateUserMetrics({ cf, env }),
     metrics.updateNftMetrics({ cf, env }),
     metrics.updatePinMetrics({ cf, env }),
-    metrics.updateFollowupMetrics({ cf, env }),
     metrics.updateDealMetrics({ cf, env }),
   ])
 }

--- a/packages/cron/src/jobs/metrics.js
+++ b/packages/cron/src/jobs/metrics.js
@@ -113,25 +113,6 @@ export async function updatePinMetrics({ cf, env }) {
 /**
  * @param {import('../types').Config} config
  */
-export async function updateFollowupMetrics({ cf, env }) {
-  const log = debug('metrics:updateFollowupMetrics')
-  const namespaces = await cf.fetchKVNamespaces()
-  const followupsNs = findNs(namespaces, env, 'FOLLOWUPS')
-  const merticsNs = findNs(namespaces, env, 'METRICS')
-  log(`🎯 Updating ${merticsNs.title} from ${followupsNs.title}`)
-  let total = 0
-  for await (const keys of cf.fetchKVKeys(followupsNs.id)) {
-    log(`📥 Processing ${total} -> ${total + keys.length}`)
-    total += keys.length
-  }
-  log(`${total} followups:total`)
-  await cf.writeKV(merticsNs.id, 'followups:total', total)
-  log('done')
-}
-
-/**
- * @param {import('../types').Config} config
- */
 export async function updateDealMetrics({ cf, env }) {
   const log = debug('metrics:updateDealMetrics')
   const namespaces = await cf.fetchKVNamespaces()


### PR DESCRIPTION
🤦‍♂️ I realised the "queued" pins metric is already effectively tracking this and so a separate metric for this is not needed (and is using a substantial amount of our rate limited api requests to do so).

<img width="689" alt="Screenshot 2021-05-17 at 21 55 11" src="https://user-images.githubusercontent.com/152863/118555947-32602200-b75b-11eb-87d4-a809779ea4f7.png">
