### PR TITLE
feat: allow extensions to ERC-1155 metadata

### DIFF
--- a/packages/client/src/lib.js
+++ b/packages/client/src/lib.js
@@ -128,43 +128,14 @@ class NFTStorage {
   /**
    * @template {API.TokenInput} T
    * @param {API.Service} service
-   * @param {T} data
+   * @param {T} metadata
    * @returns {Promise<API.Token<T>>}
    */
-  static async store(
-    { endpoint, token },
-    { name, description, image, properties, decimals, localization }
-  ) {
+  static async store({ endpoint, token }, metadata) {
+    validateERC1155(metadata)
+
     const url = new URL(`/store`, endpoint)
-    // Just validate that expected field are present
-    if (typeof name !== 'string') {
-      throw new TypeError(
-        'string property `name` identifying the asset is required'
-      )
-    }
-    if (typeof description !== 'string') {
-      throw new TypeError(
-        'string property `description` describing asset is required'
-      )
-    }
-
-    if (!(image instanceof Blob) || !image.type.startsWith('image/')) {
-      throw new TypeError(
-        'proprety `image` must be a Blob or File object with `image/*` mime type'
-      )
-    }
-    if (typeof decimals !== 'undefined' && typeof decimals !== 'number') {
-      throw new TypeError('proprety `decimals` must be an integer value')
-    }
-
-    const body = Token.encode({
-      name,
-      description,
-      image,
-      properties,
-      decimals,
-      localization,
-    })
+    const body = Token.encode(metadata)
     const paths = new Set(body.keys())
 
     const response = await fetch(url.toString(), {
@@ -373,6 +344,31 @@ class NFTStorage {
    */
   store(token) {
     return NFTStorage.store(this, token)
+  }
+}
+
+/**
+ * @param {API.TokenInput} metadata
+ */
+const validateERC1155 = ({ name, description, image, decimals }) => {
+  // Just validate that expected fields are present
+  if (typeof name !== 'string') {
+    throw new TypeError(
+      'string property `name` identifying the asset is required'
+    )
+  }
+  if (typeof description !== 'string') {
+    throw new TypeError(
+      'string property `description` describing asset is required'
+    )
+  }
+  if (!(image instanceof Blob) || !image.type.startsWith('image/')) {
+    throw new TypeError(
+      'proprety `image` must be a Blob or File object with `image/*` mime type'
+    )
+  }
+  if (typeof decimals !== 'undefined' && typeof decimals !== 'number') {
+    throw new TypeError('proprety `decimals` must be an integer value')
   }
 }
 

--- a/packages/client/test/lib.spec.js
+++ b/packages/client/test/lib.spec.js
@@ -325,6 +325,44 @@ describe('client', () => {
       assert.equal(b2.protocol, 'https:')
       assert.equal(b2.host, DWEB_LINK)
     })
+
+    it('store with OpenSea extensions', async () => {
+      const client = new NFTStorage({ token, endpoint })
+      const result = await client.store({
+        name: 'name',
+        description: 'stuff',
+        image: new File(['fake image'], 'cat.png', { type: 'image/png' }),
+        animation_url: new File(['fake vid'], 'vid.mp4', { type: 'video/mp4' }),
+        background_color: 'ffffff',
+        youtube_url: 'https://youtu.be/dQw4w9WgXcQ',
+        attributes: [
+          { trait_type: 'Aqua Power', display_type: 'boost_number' },
+        ],
+      })
+
+      assert.ok(result instanceof Token)
+
+      const cid = CID.parse(result.ipnft)
+      assert.equal(cid.version, 1)
+
+      assert.ok(typeof result.url === 'string')
+      assert.ok(result.url.startsWith('ipfs:'))
+
+      assert.equal(result.data.name, 'name')
+      assert.equal(result.data.description, 'stuff')
+      assert.equal(result.data.background_color, 'ffffff')
+      assert.equal(result.data.youtube_url, 'https://youtu.be/dQw4w9WgXcQ')
+      assert.equal(result.data.attributes, [
+        {
+          trait_type: 'Aqua Power',
+          display_type: 'boost_number',
+        },
+      ])
+      assert.ok(result.data.image instanceof URL)
+      assert.ok(result.data.image.protocol, 'ipfs:')
+      assert.ok(result.data.animation_url instanceof URL)
+      assert.ok(result.data.animation_url.protocol, 'ipfs:')
+    })
   })
 
   describe('status', () => {


### PR DESCRIPTION
This PR allows extensions to the ERC-1155 metadata format. The metadata passed must still comply to ERC-1155, but it allows extensions such as [the ones OpenSea use](https://docs.opensea.io/docs/metadata-standards#section-metadata-structure) (`animation_url`, external_url, `attributes` etc.) to also be included in the metadata.

Note that the HTTP API already supports this, the change here is to make the JS client more permissive.