### PR TITLE
chore: fix client repo link on npm listing

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -62,6 +62,11 @@
     "typedoc": "0.20.36",
     "uvu": "0.5.1"
   },
-  "homepage": "https://github.com/ipfs-shipyard/nft.storage/tree/main/client",
-  "bugs": "https://github.com/ipfs-shipyard/nft.storage/issues"
+  "homepage": "https://github.com/ipfs-shipyard/nft.storage/tree/main/packages/client",
+  "bugs": "https://github.com/ipfs-shipyard/nft.storage/issues",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/ipfs-shipyard/nft.storage.git",
+    "directory": "packages/client"
+  }
 }


### PR DESCRIPTION
- update homepage url
- add reportistory object with directory

see: https://docs.npmjs.com/cli/v7/configuring-npm/package-json#repository


License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>