### PR TITLE
docs: cleanup docs and move into proper places

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,25 +10,13 @@ Free decentralized storage and bandwidth for NFTs on IPFS and Filecoin BETA.
 - [HTTP API](#http-api)
 - [Developer Tools](#developer-tools)
 - [Development](#development)
-  - [`site` Setup](#site-setup)
-    - [Local env vars](#local-env-vars)
-    - [Cloudflare Workers CLI](#cloudflare-workers-cli)
-    - [Magic.link account](#magiclink-account)
-    - [IPFS Cluster](#ipfs-cluster)
-    - [Cloudflare Workers initial setup:](#cloudflare-workers-initial-setup)
-      - [Development Setup](#development-setup)
-      - [Production Setup `[env.production]`](#production-setup-envproduction)
-  - [`site` Usage](#site-usage)
-    - [Local development](#local-development)
-    - [Deploy](#deploy)
-  - [`website` Setup](#website-setup)
-  - [`website` Usage](#website-usage)
-    - [Local development](#local-development-1)
+  - [Getting Started](#getting-started)
+  - [Running Locally](#running-locally)
   - [Release](#release)
     - [What's a Release PR?](#whats-a-release-pr)
     - [How should I write my commits?](#how-should-i-write-my-commits)
-  - [Contributing](#contributing)
-  - [License](#license)
+- [Contributing](#contributing)
+- [License](#license)
 
 # Client Libraries
 
@@ -54,201 +42,32 @@ https://github.com/nftstorage/nft.storage-tools
 
 # Development
 
-```bash
-# install all dependencies in the mono-repo
-yarn
+Instructions for developers working on the nft.storage API and website.
 
-# setup git hooks
-npx simple-git-hooks
-```
+## Getting Started
 
-## `site` Setup
+We use `yarn` in this project and commit the `yarn.lock` file.
 
-### Local env vars
+1. Install dependencies.
+   ```bash
+   # install all dependencies in the mono-repo
+   yarn
+   # setup git hooks
+   npx simple-git-hooks
+   ```
+1. Follow the getting started guides in [`/packages/api`](/packages/api#getting-started) and [`/packages/website`](/packages/website#getting-started).
+1. Run locally by following the instructions below.
 
-Inside the `site` folder create a file called `.env.local` with the following content.
+## Running Locally
 
-```ini
-SENTRY_TOKEN=<sentry user auth token>
-SENTRY_UPLOAD=false # toggle for sentry source/sourcemaps upload (capture will still work)
-```
+To run nft.storage locally, start the following processes:
 
-Production vars should set in Github Actions secrets.
+1. Local IPFS Cluster (`docker-compose up` in your cluster home dir).
+1. Localtunnel to expose cluster (`yarn lt` in `/packages/api`).
+1. API server (`yarn dev --env USER` in `/packages/api`).
+1. Web server (`yarn dev` in `/packages/website`).
 
-### Cloudflare Workers CLI
-
-```bash
-yarn global add @cloudflare/wrangler
-wrangler login
-# when using personal accounts you may need to manually change the `account_id` inside `wrangler.toml`
-```
-
-### Magic.link account
-
-Go to [magic.link](https://magic.link) and create an account. Create two applications one for dev and another for production. In the "settings" of each application you will find the secrets needed to complete the initial setup.
-
-### IPFS Cluster
-
-The nft.storage site talks to IPFS Cluster. You need to run a cluster locally and make it accessible from the internet for development.
-
-Follow the quickstart guide to get an IPFS Cluster up and running: https://cluster.ipfs.io/documentation/quickstart/
-
-Expose the IPFS Proxy by opening the `docker-compose.yml` file and add:
-
-```yaml
-CLUSTER_IPFSPROXY_NODEMULTIADDRESS: /dns4/ipfs0/tcp/5001
-CLUSTER_IPFSPROXY_LISTENMULTIADDRESS: /ip4/0.0.0.0/tcp/9095
-```
-
-...to the `custer0` _environment_ and add:
-
-```yaml
-- '127.0.0.1:9095:9095'
-```
-
-...to the `cluster0` _ports_. Then restart for the changes to take effect.
-
-Install [localtunnel](https://localtunnel.me/) and expose the IPFS Cluster HTTP API and IPFS Proxy API (replacing "USER" with your name):
-
-```
-npm install -g localtunnel
-lt --port 9094 --subdomain USER-cluster-api-nft-storage
-lt --port 9095 --subdomain USER-ipfs-proxy-api-nft-storage
-```
-
-These two URLs should be used for `CLUSTER_API_URL` and `CLUSTER_IPFS_PROXY_API_URL` in the `wrangler.toml` (see below).
-
-There is an npm script you can use to quickly establish these tunnels during development:
-
-```sh
-npm run lt
-```
-
-### Cloudflare Workers initial setup:
-
-> This only needs to be run once when setting up from scratch.
-
-#### Development Setup
-
-Open `wrangler.toml` and add an env for yourself (replacing "USER" with your name and "CF_ACCOUNT" with your Cloudflare account):
-
-```toml
-[env.USER]
-type = "webpack"
-name = "nft-storage-USER"
-account_id = "CF_ACCOUNT"
-workers_dev = true
-route = ""
-zone_id = ""
-vars = { ENV = "dev", DEBUG = "*", CLUSTER_API_URL = "", CLUSTER_IPFS_PROXY_API_URL = "" }
-kv_namespaces = []
-```
-
-Additionally, fill in the `CLUSTER_API_URL` and `CLUSTER_IPFS_PROXY_API_URL` with the localtunnel URLs you obtained when setting up the IPFS Cluster.
-
-```bash
-cd site
-yarn install
-# dev and preview KVs
-wrangler kv:namespace create USERS --preview --env USER
-# cli output something like: `{ binding = "USERS", preview_id = "7e441603d1bc4d5a87f6cecb959018e4" }`
-# but you need to put `{ binding = "USERS", preview_id = "7e441603d1bc4d5a87f6cecb959018e4", id = "7e441603d1bc4d5a87f6cecb959018e4" }` inside the `kv_namespaces`.
-wrangler kv:namespace create NFTS --preview --env USER
-# same as above
-wrangler kv:namespace create NFTS_IDX --preview --env USER
-# same as above
-wrangler kv:namespace create DEALS --preview --env USER
-# same as above
-wrangler kv:namespace create METRICS --preview --env USER
-# same as above
-wrangler kv:namespace create PINS --preview --env USER
-# same as above
-wrangler kv:namespace create FOLLOWUPS --preview --env USER
-# same as above
-wrangler kv:namespace create PINATA_QUEUE --preview --env USER
-# same as above
-```
-
-Go to `/site/src/constants.js` _uncomment_ the first line and run `wrangler publish --env USER`.
-
-```bash
-# dev and preview secrets
-wrangler secret put MAGIC_SECRET_KEY --env USER # Get from magic.link account
-wrangler secret put SALT --env USER # open `https://csprng.xyz/v1/api` in the browser and use the value of `Data`
-wrangler secret put PINATA_JWT --env USER # Get from Pinata
-wrangler secret put SENTRY_DSN --env USER # Get from Sentry
-```
-
-Go to `/site/src/constants.js` _comment_ the first line and run `wrangler publish --env USER`.
-
-#### Production Setup `[env.production]`
-
-```bash
-# production KVs
-wrangler kv:namespace create USERS --env production
-# Follow the instructions from the cli output
-wrangler kv:namespace create NFTS --env production
-# Follow the instructions from the cli output
-wrangler kv:namespace create NFTS_IDX --env production
-# Follow the instructions from the cli output
-wrangler kv:namespace create DEALS --env production
-# Follow the instructions from the cli output
-wrangler kv:namespace create METRICS --env production
-# Follow the instructions from the cli output
-wrangler kv:namespace create PINS --env production
-# Follow the instructions from the cli output
-wrangler kv:namespace create FOLLOWUPS --env production
-# Follow the instructions from the cli output
-wrangler kv:namespace create PINATA_QUEUE --env production
-# Follow the instructions from the cli output
-wrangler secret put MAGIC_SECRET_KEY --env production # Get from magic.link account
-wrangler secret put SALT --env production # open `https://csprng.xyz/v1/api` in the browser and use the value of `Data`
-wrangler secret put PINATA_JWT --env production # Get from Pinata
-wrangler secret put CLUSTER_BASIC_AUTH_TOKEN --env production # Get from nft.storage vault in 1password
-wrangler secret put CLUSTER_IPFS_PROXY_BASIC_AUTH_TOKEN --env production # Get from nft.storage vault in 1password
-wrangler publish --env production
-```
-
-## `site` Usage
-
-### Local development
-
-```bash
-cd site
-yarn install
-yarn dev
-```
-
-### Deploy
-
-Deployment should be done with github actions but in the case you need to manually test something you can run `yarn deploy` inside the `site` folder.
-
-## `website` Setup
-
-Inside the `website` folder create a file called `.env.local` with the following content.
-
-```ini
-NEXT_PUBLIC_ENV=dev
-NEXT_PUBLIC_API=http://127.0.0.1:8787
-NEXT_PUBLIC_MAGIC=<magic test mode publishable key>
-NEXT_PUBLIC_SENTRY_DSN=<sentry dsn>
-SENTRY_URL=https://sentry.io/
-SENTRY_ORG=<sentry org name>
-SENTRY_PROJECT=<sentry project name>
-SENTRY_AUTH_TOKEN=<sentry auth token>
-```
-
-Production vars should set in Cloudflare Pages settings.
-
-## `website` Usage
-
-### Local development
-
-```bash
-cd site
-yarn install
-yarn dev
-```
+The site should now be available at http://localhost:3000
 
 ## Release
 
@@ -281,10 +100,10 @@ The most important prefixes you should have in mind are:
 - `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change
   (indicated by the `!`) and will result in a SemVer major.
 
-## Contributing
+# Contributing
 
 Feel free to join in. All welcome. [Open an issue](https://github.com/ipfs-shipyard/nft.storage/issues)!
 
-## License
+# License
 
 Dual-licensed under [MIT](https://github.com/ipfs-shipyard/nft.storage/blob/main/LICENSE-MIT) + [Apache 2.0](https://github.com/ipfs-shipyard/nft.storage/blob/main/LICENSE-APACHE)

--- a/README.md
+++ b/README.md
@@ -78,15 +78,13 @@ and creating release PRs.
 
 ### What's a Release PR?
 
-Rather than continuously releasing what's landed to our default branch,
-release-please maintains Release PRs:
+Rather than continuously releasing what's landed to our default branch, release-please maintains Release PRs:
 
-These Release PRs are kept up-to-date as additional work is merged. When we're
-ready to tag a release, we simply merge the release PR.
+These Release PRs are kept up-to-date as additional work is merged. When we're ready to tag a release, we simply merge the release PR.
 
-When the release PR is merged the release job is triggered to create a new tag, a new github release and run other package specific jobs.
+When the release PR is merged the release job is triggered to create a new tag, a new github release and run other package specific jobs. Only merge ONE release PR at a time and wait for CI to finish before merging another.
 
-Release PRs are created individually for each packages in the mono repo.
+Release PRs are created individually for each package in the mono repo.
 
 ### How should I write my commits?
 

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -8,6 +8,8 @@ The nft.storage public API.
 
 Inside the `/packages/api` folder create a file called `.env.local` with the following content.
 
+Note: tokens can be created here https://sentry.io/settings/account/api/auth-tokens/ and need the following scopes `event:admin` `event:read` `member:read` `org:read` `project:read` `project:releases` `team:read`.
+
 ```ini
 SENTRY_TOKEN=<sentry user auth token>
 SENTRY_UPLOAD=false # toggle for sentry source/sourcemaps upload (capture will still work)

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1,0 +1,160 @@
+# API
+
+The nft.storage public API.
+
+## Getting Started
+
+### Local env vars
+
+Inside the `/packages/api` folder create a file called `.env.local` with the following content.
+
+```ini
+SENTRY_TOKEN=<sentry user auth token>
+SENTRY_UPLOAD=false # toggle for sentry source/sourcemaps upload (capture will still work)
+```
+
+Production vars should set in Github Actions secrets.
+
+### Cloudflare Workers CLI
+
+```bash
+yarn global add @cloudflare/wrangler
+wrangler login
+# when using personal accounts you may need to manually change the `account_id` inside `wrangler.toml`
+```
+
+### Magic.link account
+
+Go to [magic.link](https://magic.link) and create an account. Create two applications one for dev and another for production. In the "settings" of each application you will find the secrets needed to complete the initial setup.
+
+### IPFS Cluster
+
+The nft.storage site talks to IPFS Cluster. You need to run a cluster locally and make it accessible from the internet for development.
+
+Follow the quickstart guide to get an IPFS Cluster up and running: https://cluster.ipfs.io/documentation/quickstart/
+
+Expose the IPFS Proxy by opening the `docker-compose.yml` file and add:
+
+```yaml
+CLUSTER_IPFSPROXY_NODEMULTIADDRESS: /dns4/ipfs0/tcp/5001
+CLUSTER_IPFSPROXY_LISTENMULTIADDRESS: /ip4/0.0.0.0/tcp/9095
+```
+
+...to the `custer0` _environment_ and add:
+
+```yaml
+- '127.0.0.1:9095:9095'
+```
+
+...to the `cluster0` _ports_. Then restart for the changes to take effect.
+
+Install [localtunnel](https://localtunnel.me/) and expose the IPFS Cluster HTTP API and IPFS Proxy API (replacing "USER" with your name):
+
+```
+npm install -g localtunnel
+lt --port 9094 --subdomain USER-cluster-api-nft-storage
+lt --port 9095 --subdomain USER-ipfs-proxy-api-nft-storage
+```
+
+These two URLs should be used for `CLUSTER_API_URL` and `CLUSTER_IPFS_PROXY_API_URL` in the `wrangler.toml` (see below).
+
+There is an npm script you can use to quickly establish these tunnels during development:
+
+```sh
+yarn lt
+```
+
+### Cloudflare Workers initial setup:
+
+> This only needs to be run once when setting up from scratch.
+
+#### Development Setup
+
+Open `wrangler.toml` and add an env for yourself (replacing "USER" with your name and "CF_ACCOUNT" with your Cloudflare account):
+
+```toml
+[env.USER]
+type = "webpack"
+name = "nft-storage-USER"
+account_id = "CF_ACCOUNT"
+workers_dev = true
+route = ""
+zone_id = ""
+vars = { ENV = "dev", DEBUG = "*", CLUSTER_API_URL = "", CLUSTER_IPFS_PROXY_API_URL = "" }
+kv_namespaces = []
+```
+
+Additionally, fill in the `CLUSTER_API_URL` and `CLUSTER_IPFS_PROXY_API_URL` with the localtunnel URLs you obtained when setting up the IPFS Cluster.
+
+```bash
+cd packages/api
+yarn install
+# dev and preview KVs
+wrangler kv:namespace create USERS --preview --env USER
+# cli output something like: `{ binding = "USERS", preview_id = "7e441603d1bc4d5a87f6cecb959018e4" }`
+# but you need to put `{ binding = "USERS", preview_id = "7e441603d1bc4d5a87f6cecb959018e4", id = "7e441603d1bc4d5a87f6cecb959018e4" }` inside the `kv_namespaces`.
+wrangler kv:namespace create NFTS --preview --env USER
+# same as above
+wrangler kv:namespace create NFTS_IDX --preview --env USER
+# same as above
+wrangler kv:namespace create DEALS --preview --env USER
+# same as above
+wrangler kv:namespace create METRICS --preview --env USER
+# same as above
+wrangler kv:namespace create PINS --preview --env USER
+# same as above
+wrangler kv:namespace create FOLLOWUPS --preview --env USER
+# same as above
+wrangler kv:namespace create PINATA_QUEUE --preview --env USER
+# same as above
+```
+
+Go to `/packages/api/src/constants.js` _uncomment_ the first line and run `wrangler publish --env USER`.
+
+```bash
+# dev and preview secrets
+wrangler secret put MAGIC_SECRET_KEY --env USER # Get from magic.link account
+wrangler secret put SALT --env USER # open `https://csprng.xyz/v1/api` in the browser and use the value of `Data`
+wrangler secret put PINATA_JWT --env USER # Get from Pinata
+wrangler secret put SENTRY_DSN --env USER # Get from Sentry
+```
+
+Go to `/packages/api/src/constants.js` _comment_ the first line and run `wrangler publish --env USER`.
+
+#### Production Setup `[env.production]`
+
+```bash
+# production KVs
+wrangler kv:namespace create USERS --env production
+# Follow the instructions from the cli output
+wrangler kv:namespace create NFTS --env production
+# Follow the instructions from the cli output
+wrangler kv:namespace create NFTS_IDX --env production
+# Follow the instructions from the cli output
+wrangler kv:namespace create DEALS --env production
+# Follow the instructions from the cli output
+wrangler kv:namespace create METRICS --env production
+# Follow the instructions from the cli output
+wrangler kv:namespace create PINS --env production
+# Follow the instructions from the cli output
+wrangler kv:namespace create FOLLOWUPS --env production
+# Follow the instructions from the cli output
+wrangler kv:namespace create PINATA_QUEUE --env production
+# Follow the instructions from the cli output
+wrangler secret put MAGIC_SECRET_KEY --env production # Get from magic.link account
+wrangler secret put SALT --env production # open `https://csprng.xyz/v1/api` in the browser and use the value of `Data`
+wrangler secret put PINATA_JWT --env production # Get from Pinata
+wrangler secret put CLUSTER_BASIC_AUTH_TOKEN --env production # Get from nft.storage vault in 1password
+wrangler secret put CLUSTER_IPFS_PROXY_BASIC_AUTH_TOKEN --env production # Get from nft.storage vault in 1password
+wrangler publish --env production
+```
+
+## Usage
+
+### Running Locally
+
+```bash
+cd packages/api
+yarn install
+yarn dev --env USER
+```

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -82,7 +82,7 @@ account_id = "CF_ACCOUNT"
 workers_dev = true
 route = ""
 zone_id = ""
-vars = { ENV = "dev", DEBUG = "*", CLUSTER_API_URL = "", CLUSTER_IPFS_PROXY_API_URL = "" }
+vars = { ENV = "dev", DEBUG = "*", CLUSTER_API_URL = "", CLUSTER_IPFS_PROXY_API_URL = "", CLUSTER_ADDRS = "" }
 kv_namespaces = []
 ```
 

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -13,7 +13,7 @@ SENTRY_TOKEN=<sentry user auth token>
 SENTRY_UPLOAD=false # toggle for sentry source/sourcemaps upload (capture will still work)
 ```
 
-Production vars should set in Github Actions secrets.
+Production vars should be set in Github Actions secrets.
 
 ### Cloudflare Workers CLI
 

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -88,6 +88,16 @@ kv_namespaces = []
 
 Additionally, fill in the `CLUSTER_API_URL` and `CLUSTER_IPFS_PROXY_API_URL` with the localtunnel URLs you obtained when setting up the IPFS Cluster.
 
+e.g.
+
+```js
+CLUSTER_API_URL = 'https://USER-cluster-api-nft-storage.loca.lt'
+CLUSTER_IPFS_PROXY_API_URL =
+  'https://USER-ipfs-proxy-api-nft-storage.loca.lt/api/v0/'
+```
+
+Now run the following to install dependencies and create KV namespaces on Cloudflare:
+
 ```bash
 cd packages/api
 yarn install

--- a/packages/api/src/constants.js
+++ b/packages/api/src/constants.js
@@ -1,4 +1,4 @@
-// let MAGIC_SECRET_KEY, SALT, PINATA_JWT
+// let MAGIC_SECRET_KEY, SALT, PINATA_JWT, SENTRY_DSN
 export const stores = {
   deals: DEALS,
   users: USERS,

--- a/packages/website/README.md
+++ b/packages/website/README.md
@@ -2,24 +2,29 @@
 
 Frontend build for the nft.storage website.
 
-## Getting started
+## Getting Started
 
-Install Node.js 12+ and then dependencies:
+Inside the `/packages/website` folder create a file called `.env.local` with the following content.
 
-```sh
-npm install
+```ini
+NEXT_PUBLIC_ENV=dev
+NEXT_PUBLIC_API=http://127.0.0.1:8787
+NEXT_PUBLIC_MAGIC=<magic test mode publishable key>
+NEXT_PUBLIC_SENTRY_DSN=<sentry dsn>
+SENTRY_URL=https://sentry.io/
+SENTRY_ORG=<sentry org name>
+SENTRY_PROJECT=<sentry project name>
+SENTRY_AUTH_TOKEN=<sentry auth token>
 ```
 
-### Local development
+Production vars should set in Cloudflare Pages settings.
 
-```sh
-npm run dev
+## Usage
+
+### Running Locally
+
+```bash
+cd packages/website
+yarn install
+yarn dev
 ```
-
-### Production build
-
-```sh
-npm run build
-```
-
-Will build to a directory called `out`.


### PR DESCRIPTION
* Moves `api` and `website` getting started documentation into the proper directories
* Adds overview documentation to the README at the root and instructions for running locally