### PR TITLE
chore: use node 16 in CI

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '16'
       - uses: bahmutov/npm-install@v1
       - run: yarn test:api
   deploy-dev:
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - name: Publish app
         uses: cloudflare/wrangler-action@1.3.0
         env:
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - name: Publish app
         uses: cloudflare/wrangler-action@1.3.0
         env:

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -17,6 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
       - uses: bahmutov/npm-install@v1
       - name: Typecheck
         uses: gozala/typescript-error-reporter-action@v1.0.8
@@ -33,23 +36,15 @@ jobs:
       fail-fast: true
     steps:
       - uses: actions/checkout@v2
-
-      - name: Setup node
-        uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
-
-      - name: Install dependencies
-        uses: bahmutov/npm-install@v1
-
+      - name: bahmutov/npm-install@v1
       - name: Test (ES)
         run: yarn --cwd packages/client test:es
-
       - name: Test (Web)
         run: yarn --cwd packages/client test:web
-
       - name: Test (CJS)
         run: yarn --cwd packages/client test:cjs
-
       - name: Coverage
         run: yarn --cwd packages/client coverage

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
-      - name: bahmutov/npm-install@v1
+      - uses: bahmutov/npm-install@v1
       - name: Test (ES)
         run: yarn --cwd packages/client test:es
       - name: Test (Web)

--- a/.github/workflows/cron-metrics.yml
+++ b/.github/workflows/cron-metrics.yml
@@ -13,15 +13,10 @@ jobs:
         env: ['staging', 'production']
     steps:
       - uses: actions/checkout@v2
-
-      - name: Setup node
-        uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: 15
-
-      - name: Install dependencies
-        uses: bahmutov/npm-install@v1
-
+          node-version: 16
+      - uses: bahmutov/npm-install@v1
       - name: Run job
         env:
           DEBUG: '*'

--- a/.github/workflows/cron-pinata.yml
+++ b/.github/workflows/cron-pinata.yml
@@ -13,15 +13,10 @@ jobs:
         env: ['staging', 'production']
     steps:
       - uses: actions/checkout@v2
-
-      - name: Setup node
-        uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: 15
-
-      - name: Install dependencies
-        run: yarn install
-
+          node-version: 16
+      - uses: bahmutov/npm-install@v1
       - name: Run job
         env:
           DEBUG: '*'

--- a/.github/workflows/cron-pins.yml
+++ b/.github/workflows/cron-pins.yml
@@ -14,15 +14,10 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
-
-      - name: Setup node
-        uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: 15
-
-      - name: Install dependencies
-        uses: bahmutov/npm-install@v1
-
+          node-version: 16
+      - uses: bahmutov/npm-install@v1
       - name: Run job
         env:
           DEBUG: '*'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
   deploy-api:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - name: Publish app
         uses: cloudflare/wrangler-action@1.3.0
         env:
@@ -35,7 +35,10 @@ jobs:
     if: github.event.inputs.environment == 'production'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
       - uses: bahmutov/npm-install@v1
       - run: ./packages/tools/cli.js dns --name nft.storage --token ${{ secrets.CF_API_TOKEN }} --zone ${{ secrets.CLOUDFLARE_ZONE }} --content ${{ github.event.inputs.frontend_cname }}
       - run: echo "::warning::https://nft.storage"
@@ -43,7 +46,10 @@ jobs:
     if: github.event.inputs.environment == 'staging'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
       - uses: bahmutov/npm-install@v1
       - run: ./packages/tools/cli.js dns --name staging.nft.storage --token ${{ secrets.CF_API_TOKEN }} --zone ${{ secrets.CLOUDFLARE_ZONE }} --content ${{ github.event.inputs.frontend_cname }}
       - run: echo "::warning::https://staging.nft.storage"
@@ -51,7 +57,10 @@ jobs:
     if: github.event.inputs.environment == ''
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
       - uses: bahmutov/npm-install@v1
       - run: ./packages/tools/cli.js dns --name dev.nft.storage --token ${{ secrets.CF_API_TOKEN }} --zone ${{ secrets.CLOUDFLARE_ZONE }} --content ${{ github.event.inputs.frontend_cname }}
       - run: echo "::warning::https://dev.nft.storage"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/setup-node@v2
         if: ${{ steps.tag-release.outputs.release_created }}
         with:
-          node-version: '14'
+          node-version: '16'
           registry-url: 'https://registry.npmjs.org'
       - name: Install
         if: ${{ steps.tag-release.outputs.release_created }}

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -16,6 +16,9 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
       - uses: bahmutov/npm-install@v1
       - run: yarn test:website


### PR DESCRIPTION
update all workflows to use:
- actions/setup-node@v2 with `node-version: 16`
- actions/checkout@v2
- bahmutov/npm-install@v1

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>