### PR TITLE
fix(client): npm lifecycle build command

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -32,7 +32,7 @@
     "build:cjs": "rollup --config rollup.config.js",
     "coverage": "nyc report --reporter=text-lcov > coverage.lcov && npx codecov",
     "typedoc": "typedoc --entryPoints src  --out ../../docs/client",
-    "prepare": "npm run build"
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@web-std/blob": "^2.1.0",


### PR DESCRIPTION
Fix local `npm install` in a project that doesn't have `npm-run-all` installed. I think because we're using `prepare` "Runs on local npm install without any arguments" (https://docs.npmjs.com/cli/v6/using-npm/scripts).

<img width="523" alt="Screenshot 2021-06-18 at 10 12 06" src="https://user-images.githubusercontent.com/152863/122540820-e8e84880-d020-11eb-86f6-094d426f8ee8.png">

This PR switches to use **`prepublishOnly`**.
