### PR TITLE
feat: deal data selector

### DIFF
--- a/packages/client/src/lib/interface.ts
+++ b/packages/client/src/lib/interface.ts
@@ -145,7 +145,10 @@ export interface FinalizedDeal extends DealInfo {
    * Identifier for the deal stored on chain.
    */
   chainDealID: number
-
+  /**
+   * Selector for extracting stored data from the batch root.
+   */
+  datamodelSelector: string
   /**
    * Deal Activation
    */


### PR DESCRIPTION
The deal data selector is now available so if folks actually want to retrieve data from Filecoin they'll soon be able to use this (🔜 currently needs custom lotus client filecoin-project/lotus#6393).

@ribasushi can you confirm this is just for "active" and "terminated" deals?

resolves #192