### PR TITLE
fix: chunking issues

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -48,8 +48,5 @@
     "readable-stream": "^3.6.0",
     "smoke": "^3.1.1",
     "webpack": "^4.0.0"
-  },
-  "resolutions": {
-    "url-regex-safe": "^2.0.2"
   }
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -22,7 +22,7 @@
     "@ipld/car": "^1.0.1",
     "@ipld/dag-cbor": "^5.0.0",
     "@magic-sdk/admin": "^1.3.0",
-    "@nftstorage/ipfs-cluster": "^3.0.1",
+    "@nftstorage/ipfs-cluster": "^3.1.1",
     "debug": "^4.3.1",
     "just-safe-set": "^2.2.1",
     "merge-options": "^3.0.4",
@@ -48,5 +48,8 @@
     "readable-stream": "^3.6.0",
     "smoke": "^3.1.1",
     "webpack": "^4.0.0"
+  },
+  "resolutions": {
+    "url-regex-safe": "^2.0.2"
   }
 }

--- a/packages/api/src/cluster.js
+++ b/packages/api/src/cluster.js
@@ -12,10 +12,12 @@ const client = new Cluster(cluster.apiUrl, {
 
 /**
  * @param {Blob} data
+ * @param {import('@nftstorage/ipfs-cluster').AddParams} options
  */
-export async function add(data) {
+export async function add(data, options = {}) {
   const { cid, size, bytes } = await client.add(data, {
     metadata: { size: data.size.toString() },
+    ...options,
   })
   return {
     cid,
@@ -30,7 +32,9 @@ export async function add(data) {
 export async function addDirectory(files) {
   const size = files.reduce((total, f) => total + f.size, 0)
   if (size === 0) {
-    throw new HTTPError('Content added contains 0 bytes. Please make sure that files are encoded correctly')
+    throw new HTTPError(
+      'Content added contains 0 bytes. Please make sure that files are encoded correctly'
+    )
   }
 
   const results = await client.addDirectory(files, {

--- a/packages/api/src/routes/nfts-upload.js
+++ b/packages/api/src/routes/nfts-upload.js
@@ -9,6 +9,7 @@ import { validate } from '../utils/auth.js'
 import { debug } from '../utils/debug.js'
 
 const log = debug('nfts-upload')
+const LOCAL_ADD_THRESHOLD = 1024 * 1024 * 2.5
 
 /**
  * @typedef {import('../bindings').NFT} NFT
@@ -49,12 +50,16 @@ export async function upload(event, ctx) {
     if (blob.size === 0) {
       throw new HTTPError('Empty payload', 400)
     }
+    const isCar = contentType.includes('application/car')
     // Ensure car blob.type is set; it is used by the cluster client to set the foramt=car flag on the /add call.
-    const content = contentType.includes('application/car')
-      ? blob.slice(0, blob.size, 'application/car')
-      : blob
+    const content = isCar ? blob.slice(0, blob.size, 'application/car') : blob
     // cluster returns `bytes` rather than `size` when upload is a CAR.
-    const { cid, size, bytes } = await cluster.add(content)
+    const { cid, size, bytes } = await cluster.add(content, {
+      // When >2.5MB, use local add, because waiting for blocks to be sent to
+      // other cluster nodes can take a long time. Replication to other nodes
+      // will be done async by bitswap instead.
+      local: blob.size > LOCAL_ADD_THRESHOLD,
+    })
     nft = {
       cid,
       created,
@@ -62,12 +67,14 @@ export async function upload(event, ctx) {
       scope: tokenName,
       files: [],
     }
-    nftSize = size || bytes
+    // Size for CAR files is not reliable as they can be partials.
+    nftSize = isCar ? 0 : size || bytes
   }
 
   let pin = await pins.get(nft.cid)
-  if (!pin || pin.status !== 'pinned') {
-    pin = { cid: nft.cid, status: 'pinned', size: nftSize, created }
+  if (!pin) {
+    const status = cluster.toPSAStatus(await cluster.status(nft.cid))
+    pin = { cid: nft.cid, status, size: nftSize, created }
     await pins.set(nft.cid, pin)
   }
 

--- a/packages/api/src/routes/nfts-upload.js
+++ b/packages/api/src/routes/nfts-upload.js
@@ -67,8 +67,7 @@ export async function upload(event, ctx) {
       scope: tokenName,
       files: [],
     }
-    // Size for CAR files is not reliable as they can be partials.
-    nftSize = isCar ? 0 : size || bytes
+    nftSize = size || bytes
   }
 
   let pin = await pins.get(nft.cid)

--- a/packages/api/test/mocks/cluster/get_pins#@cid.js
+++ b/packages/api/test/mocks/cluster/get_pins#@cid.js
@@ -1,0 +1,17 @@
+/**
+ * @param {{ params: Record<string, string> }} request
+ */
+module.exports = async ({ params }) => ({
+  statusCode: 200,
+  headers: { 'Content-Type': 'application/json' },
+  body: {
+    cid: { '/': params.cid },
+    peer_map: {
+      FAKEPEERID: {
+        peerName: 'Cluster Node 0',
+        status: 'pinned',
+        timestamp: new Date().toISOString(),
+      },
+    },
+  },
+})

--- a/packages/client/src/lib.js
+++ b/packages/client/src/lib.js
@@ -15,7 +15,7 @@
  */
 
 // @ts-ignore module with no types
-import { parallelMap } from 'streaming-iterables'
+import { transform } from 'streaming-iterables'
 import pRetry from 'p-retry'
 
 import { CarReader } from '@ipld/car'
@@ -28,7 +28,7 @@ import { toGatewayURL } from './gateway.js'
 
 const MAX_STORE_RETRIES = 5
 const MAX_CONCURRENT_UPLOADS = 3
-const MAX_CHUNK_SIZE = 1024 * 1024 * 99 // chunk to ~99MB CARs
+const MAX_CHUNK_SIZE = 1024 * 1024 * 10 // chunk to ~10MB CARs
 
 /**
  * @implements API.Service
@@ -117,7 +117,7 @@ class NFTStorage {
         ? await TreewalkCarSplitter.fromBlob(car, targetSize)
         : new TreewalkCarSplitter(car, targetSize)
 
-    const upload = parallelMap(
+    const upload = transform(
       MAX_CONCURRENT_UPLOADS,
       async (/** @type {AsyncIterable<Uint8Array>} */ car) => {
         const carParts = []

--- a/packages/client/test/lib.spec.js
+++ b/packages/client/test/lib.spec.js
@@ -147,7 +147,7 @@ describe('client', () => {
           uploadedChunks++
         },
       })
-      assert.equal(uploadedChunks, 12)
+      assert.ok(uploadedChunks >= 12)
       assert.equal(cid, expectedCid)
     })
   })
@@ -633,6 +633,12 @@ describe('client', () => {
 
 const MAX_BLOCK_SIZE = 1024 * 1024 * 4
 
+function randomBlockSize() {
+  const max = MAX_BLOCK_SIZE
+  const min = max / 2
+  return Math.random() * (max - min) + min
+}
+
 /**
  * @param {number} targetSize
  * @returns {Promise<AsyncIterable<Uint8Array>>}
@@ -643,7 +649,7 @@ async function randomCar(targetSize) {
   const seen = new Set()
   while (size < targetSize) {
     const bytes = dagCbor.encode(
-      garbage(targetSize / MAX_BLOCK_SIZE, { weights: { CID: 0 } })
+      garbage(randomBlockSize(), { weights: { CID: 0 } })
     )
     const hash = await sha256.digest(bytes)
     const cid = CID.create(1, dagCbor.code, hash)

--- a/packages/client/test/lib.spec.js
+++ b/packages/client/test/lib.spec.js
@@ -147,7 +147,7 @@ describe('client', () => {
           uploadedChunks++
         },
       })
-      assert.equal(uploadedChunks, 2)
+      assert.equal(uploadedChunks, 12)
       assert.equal(cid, expectedCid)
     })
   })
@@ -631,6 +631,8 @@ describe('client', () => {
   })
 })
 
+const MAX_BLOCK_SIZE = 1024 * 1024 * 4
+
 /**
  * @param {number} targetSize
  * @returns {Promise<AsyncIterable<Uint8Array>>}
@@ -641,7 +643,7 @@ async function randomCar(targetSize) {
   const seen = new Set()
   while (size < targetSize) {
     const bytes = dagCbor.encode(
-      garbage(targetSize / 6, { weights: { CID: 0 } })
+      garbage(targetSize / MAX_BLOCK_SIZE, { weights: { CID: 0 } })
     )
     const hash = await sha256.digest(bytes)
     const cid = CID.create(1, dagCbor.code, hash)

--- a/packages/cron/package.json
+++ b/packages/cron/package.json
@@ -19,7 +19,7 @@
   "author": "Alan Shaw",
   "license": "(Apache-2.0 AND MIT)",
   "dependencies": {
-    "@nftstorage/ipfs-cluster": "^3.0.0",
+    "@nftstorage/ipfs-cluster": "^3.1.1",
     "debug": "^4.3.1",
     "dotenv": "^9.0.2",
     "form-data": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -452,11 +452,6 @@
   resolved "https://registry.yarnpkg.com/@next/react-refresh-utils/-/react-refresh-utils-10.2.3.tgz#2f3e42fe6680798f276e3621345c2886b231348b"
   integrity sha512-qtBF56vPC6d6a8p7LYd0iRjW89fhY80kAIzmj+VonvIGjK/nymBjcFUhbKiMFqlhsarCksnhwX+Zmn95Dw9qvA==
 
-"@nftstorage/ipfs-cluster@^3.0.0":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@nftstorage/ipfs-cluster/-/ipfs-cluster-3.0.1.tgz#74e8d5809a12b1fcfe627c65b12845c09f9d0da2"
-  integrity sha512-/AxtGKJAoi/b8Bp37ZXJRP1eTUarGcvLMtsJm3NI/31jN3hrxvMl+/RUkYdBEcrctd51p0Qs2MDrEqa5ymZWQQ==
-
 "@nftstorage/ipfs-cluster@^3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@nftstorage/ipfs-cluster/-/ipfs-cluster-3.1.1.tgz#075019a8a78e833dc85abc69115f4a0425e5e8bf"

--- a/yarn.lock
+++ b/yarn.lock
@@ -452,10 +452,15 @@
   resolved "https://registry.yarnpkg.com/@next/react-refresh-utils/-/react-refresh-utils-10.2.3.tgz#2f3e42fe6680798f276e3621345c2886b231348b"
   integrity sha512-qtBF56vPC6d6a8p7LYd0iRjW89fhY80kAIzmj+VonvIGjK/nymBjcFUhbKiMFqlhsarCksnhwX+Zmn95Dw9qvA==
 
-"@nftstorage/ipfs-cluster@^3.0.0", "@nftstorage/ipfs-cluster@^3.0.1":
+"@nftstorage/ipfs-cluster@^3.0.0":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@nftstorage/ipfs-cluster/-/ipfs-cluster-3.0.1.tgz#74e8d5809a12b1fcfe627c65b12845c09f9d0da2"
   integrity sha512-/AxtGKJAoi/b8Bp37ZXJRP1eTUarGcvLMtsJm3NI/31jN3hrxvMl+/RUkYdBEcrctd51p0Qs2MDrEqa5ymZWQQ==
+
+"@nftstorage/ipfs-cluster@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@nftstorage/ipfs-cluster/-/ipfs-cluster-3.1.1.tgz#075019a8a78e833dc85abc69115f4a0425e5e8bf"
+  integrity sha512-xlfP08xM0wiQEkACpa+hTwwd49maqLjvG7xvxLmV2QIwsBssPwKBZ4rQ0wkJ7Zq3yuWosQUUSksH9rmHK99nOQ==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"


### PR DESCRIPTION
* Uses `local` option for Cluster when file is >2.5MB (size recommended by @hsanjuan). This causes cluster to add blocks to the local node only (instead of sending to all cluster nodes) and relies on bitswap to efficiently distibute the blocks asyncronously. It allows the request to complete sooner and speeds up uploads significantly.
* Uses `transform` from `streaming-iterables` instead of `parallelMap`. The `parallelMap` function is actually a parallel batch, so if 1 of the 3 concurrent requests stalls and the other 2 complete then we have to wait before starting a new batch of 3.
* Does not assume pinned status after file upload to Cluster - when creating the pin, Cluster is checked for status (resolves https://github.com/ipfs-shipyard/nft.storage/issues/191)
* Changes `MAX_CHUNK_SIZE` to 10MB - this effectively ensures we get feedback quicker and keeps our requests light enough that if a failure occurs it's not too disasterous to retry.