### PR TITLE
fix: the CarReader type is a collection of interfaces

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -39,7 +39,7 @@
     "@web-std/fetch": "^2.0.1",
     "@web-std/file": "^1.1.0",
     "@web-std/form-data": "^2.1.0",
-    "carbites": "^1.0.3",
+    "carbites": "^1.0.6",
     "p-retry": "^4.5.0",
     "streaming-iterables": "^6.0.0"
   },

--- a/packages/client/src/lib.js
+++ b/packages/client/src/lib.js
@@ -17,10 +17,7 @@
 // @ts-ignore module with no types
 import { transform } from 'streaming-iterables'
 import pRetry from 'p-retry'
-
-import { CarReader } from '@ipld/car'
-import { TreewalkCarSplitter } from 'carbites'
-
+import { TreewalkCarSplitter } from 'carbites/treewalk'
 import * as API from './lib/interface.js'
 import * as Token from './token.js'
 import { fetch, File, Blob, FormData } from './platform.js'
@@ -106,7 +103,7 @@ class NFTStorage {
   }
   /**
    * @param {API.Service} service
-   * @param {Blob|CarReader} car
+   * @param {Blob|API.CarReader} car
    * @param {{onStoredChunk?: (size: number) => void}} [options]
    * @returns {Promise<API.CIDString>}
    */
@@ -324,7 +321,7 @@ class NFTStorage {
    * const cid = await client.storeCar(car)
    * console.assert(cid === expectedCid)
    * ```
-   * @param {Blob|CarReader} car
+   * @param {Blob|API.CarReader} car
    * @param {{onStoredChunk?: (size: number) => void}} [options]
    */
   storeCar(car, options) {

--- a/packages/client/src/lib/interface.ts
+++ b/packages/client/src/lib/interface.ts
@@ -1,7 +1,8 @@
 import type { CID } from 'multiformats'
 export type { CID }
 
-import type { CarReader } from '@ipld/car'
+import type { RootsReader, BlockReader } from '@ipld/car/api'
+type CarReader = RootsReader & BlockReader
 export type { CarReader }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2163,7 +2163,7 @@ capture-stack-trace@^1.0.0:
   resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz#a6c0bbe1f38f3aa0b92238ecb6ff42c344d4135d"
   integrity sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==
 
-carbites@^1.0.3:
+carbites@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/carbites/-/carbites-1.0.6.tgz#0eac206c87b60e09b758a4e820af000dda4f8dd1"
   integrity sha512-dS9IQvnrb5VIRvSTNz5Ff+mB9d2MFfi5mojtJi7Rlss79VeF190jr0sZdA7eW0CGHotvHkZaWuM6wgfD9PEFRg==
@@ -7016,19 +7016,6 @@ nft.storage@^1.3.1:
     "@web-std/file" "1.0.1"
     "@web-std/form-data" "2.0.0"
 
-nft.storage@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/nft.storage/-/nft.storage-3.0.0.tgz#107111b5daaf850a7f539ec640290e09df8247a6"
-  integrity sha512-Xld4vVOCiLXXttC9p29+15mkZskJJAhympi6V2911xH4tUlfpFSyPm0ZPZFZ0rQl61o51q6438G4rhPjzNCKOQ==
-  dependencies:
-    "@web-std/blob" "^2.1.0"
-    "@web-std/fetch" "^2.0.1"
-    "@web-std/file" "^1.1.0"
-    "@web-std/form-data" "^2.1.0"
-    carbites "^1.0.3"
-    p-retry "^4.5.0"
-    streaming-iterables "^6.0.0"
-
 nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
@@ -7476,12 +7463,12 @@ p-queue@^6.0.0, p-queue@^6.6.2:
     p-timeout "^3.2.0"
 
 p-retry@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-4.5.0.tgz#6685336b3672f9ee8174d3769a660cb5e488521d"
-  integrity sha512-5Hwh4aVQSu6BEP+w2zKlVXtFAaYQe1qWuVADSgoeVlLjwe/Q/AMSoRR4MDeaAfu8llT+YNbEijWu/YF3m6avkg==
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-4.6.0.tgz#9de15ae696278cffe86fce2d8f73b7f894f8bc9e"
+  integrity sha512-SAHbQEwg3X5DRNaLmWjT+DlGc93ba5i+aP3QLfVNDncQEQO4xjbYW4N/lcVTSuP0aJietGfx2t94dJLzfBMpXw==
   dependencies:
     "@types/retry" "^0.12.0"
-    retry "^0.12.0"
+    retry "^0.13.1"
 
 p-timeout@^3.0.0, p-timeout@^3.2.0:
   version "3.2.0"
@@ -8549,6 +8536,11 @@ retry@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
   integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
+
+retry@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
+  integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
 
 reusify@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
This resolves type errors for folks wishing to pass a `CarIndexedReader` to `storeCar`.

`CarIndexedReader` does not extend the `CarReader` class but they both implement `RootsReader` and `BlockReader`...and these are the interfaces carbites needs.

https://github.com/ipld/js-car/blob/da397a8b3659a3e3ead9411746962885537ec1ac/api.ts#L49