### PR TITLE
chore: remove pre-push hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "apply-migrations": "yarn --cwd packages/database apply-migrations"
   },
   "simple-git-hooks": {
-    "pre-commit": "npx lint-staged",
-    "pre-push": "yarn test"
+    "pre-commit": "npx lint-staged"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,md,html,css,fql,graphql}": "prettier --write"


### PR DESCRIPTION
I propose we remove pre-push hook. Often times it test things I have not changed and just gets in the way. I find myself using `--no-verify ` a lot.

We also run tests in pulls and pushes which is free of env bias. So I propose we remove this and just lean on CI before merging things.