### PR TITLE
feat: migrate status index to task queue

### DIFF
--- a/.github/workflows/migration-2021-08-18.yml
+++ b/.github/workflows/migration-2021-08-18.yml
@@ -1,0 +1,29 @@
+name: Migrate TokenAsset status to a task queue
+
+on:
+  workflow_dispatch:
+
+jobs:
+  migrate:
+    name: Migrate TokenAsset status to a task queue
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+
+      - name: Install dependencies
+        run: yarn --cwd packages/database install
+
+      - name: Run job
+        env:
+          FAUNA_KEY: ${{ secrets.FAUNA_KEY }}
+          NIFTYSAVE_CLUSTER_KEY: ${{ secrets.NIFTYSAVE_CLUSTER_KEY }}
+          NIFTYSAVE_IPFS_API_KEY: ${{ secrets.NIFTYSAVE_IPFS_API_KEY }}
+          BATCH_SIZE: 100
+          TIME_BUDGET: 1620
+          FETCH_TIMEOUT: 10000
+        run: node packages/database/src/migrations/2021-08-18-token-asset-queue.js

--- a/packages/database/src/config.js
+++ b/packages/database/src/config.js
@@ -3,7 +3,6 @@ import yargs from 'yargs'
 
 /**
  * @typedef {import('./migration').Config} Config
- * @returns {Promise<Config>} config
  */
 export default async () => {
   dotenv.config()
@@ -14,6 +13,15 @@ export default async () => {
         default: process.env['FAUNA_KEY'],
         description: 'Fauna DB access token',
         demandOption: true,
+      },
+      size: {
+        type: 'number',
+        default: parseInt(process.env['BATCH_SIZE'] || '100'),
+        description: 'Number of items to process at once',
+      },
+      cursor: {
+        default: process.env['CURSOR'],
+        description: 'Cursor to use in the db',
       },
     })
     .parse()

--- a/packages/database/src/migrations/2021-08-18-token-asset-queue.js
+++ b/packages/database/src/migrations/2021-08-18-token-asset-queue.js
@@ -1,0 +1,104 @@
+import { script } from 'subprogram'
+import readConfig from '../config.js'
+import fauna from 'faunadb'
+
+const {
+  Client,
+  Function,
+  Delete,
+  Create,
+  Collection,
+  Get,
+  Call,
+  Var,
+  Documents,
+  Lambda,
+  Paginate,
+  Ref,
+  Map,
+  Do,
+} = fauna
+
+export const main = async () => await run(await readConfig())
+
+/**
+ *
+ * @param {migration.Config} config
+ */
+export const run = async (config) => {
+  console.log(`🚧 Performing migration`)
+
+  const client = new Client({ secret: config.secret })
+  const cursor = config.cursor
+    ? Ref(Collection('TokenAsset', options.cursor))
+    : null
+  const state = { cursor, linked: 0, failed: 0, queued: 0 }
+
+  while (true) {
+    // Fetch page of TokenAsset from the db.
+    const { after, data } = await client.query(
+      Map(
+        Paginate(Documents(Collection('TokenAsset'))),
+        Lambda(['ref'], Get(Var('ref')))
+      ),
+      {
+        size: config.size,
+        after: state.cursor,
+      }
+    )
+
+    // Create a document that corresponds to it's status
+    const expressions = []
+    for (const tokenAsset of data) {
+      switch (tokenAsset.status) {
+        case 'Linked':
+          stats.linked += 1
+          expressions.push(
+            Create(Collection('Analyzed'), {
+              data: {
+                tokenAsset: tokenAsset.ref,
+                attempt: 1,
+              },
+            })
+          )
+          break
+        case 'Queued':
+          stats.queued += 1
+          expressions.push(
+            Create(Collection('ScheduledAnalyze'), {
+              data: {
+                tokenAsset: tokenAsset.ref,
+                attempt: 1,
+              },
+            })
+          )
+          break
+        default:
+          expressions.push(
+            Create(Collection('FailedAnalyze'), {
+              data: {
+                tokenAsset: tokenAsset.ref,
+                attempt: 1,
+                status: tokenAsset.status,
+                statusText: statusText.statusText,
+              },
+            })
+          )
+          stats.failed += 1
+          break
+      }
+    }
+
+    // If there was nothing we're done
+    if (expressions.length === 0) {
+      console.log('🏁 Migration is complete', state)
+      break
+    } else {
+      await client.query(Do(expressions))
+      state.cursor = after
+      console.log('⏭ Moving to next page', state)
+    }
+  }
+}
+
+script({ ...import.meta, main })


### PR DESCRIPTION
Followup for #278 to go over all existing TokenAsset records and create pointers to it from corresponding queues 