### PR TITLE
fix: pin ipfs-car verion to avoid empty upload issue

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -15,7 +15,7 @@
     "bytes": "^3.1.0",
     "clsx": "^1.1.1",
     "filesize": "^6.1.0",
-    "ipfs-car": "^0.5.6",
+    "ipfs-car": "0.4.3",
     "magic-sdk": "^4.2.1",
     "nft.storage": "^3.0.0",
     "react": "17.0.2",


### PR DESCRIPTION
uploading via website fails with ipfs-car>=0.5 (you get an empty dir with cid `bafybeiczsscdsbs7ffqz55asqdf3smv6klcw3gofszvwlyarci47bgf354` for all uploads). Rolling back as a quick fix.

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>