### PR TITLE
feat: postgres schema

### DIFF
--- a/packages/db/cargo-fdw.sql
+++ b/packages/db/cargo-fdw.sql
@@ -1,0 +1,33 @@
+CREATE EXTENSION IF NOT EXISTS postgres_fdw;
+
+CREATE SERVER dagcargo
+  FOREIGN DATA WRAPPER postgres_fdw
+  OPTIONS (host '{CARGO_HOST}', port '5432', dbname '{CARGO_DB_NAME}', fetch_size '50000');
+
+CREATE USER MAPPING FOR {DB_USER}
+  SERVER dagcargo
+  OPTIONS (user '{CARGO_USER}', password '{CARGO_PASSWORD}');
+
+-- Import foreign data into the cargo schema, create materialized views in
+-- public schema.
+CREATE SCHEMA cargo;
+
+IMPORT FOREIGN SCHEMA cargo
+  LIMIT TO (deals, aggregates, aggregate_entries)
+  FROM SERVER dagcargo
+  INTO cargo;
+
+-- Singular table names to retain consistency with our schema.
+CREATE MATERIALIZED VIEW public.deal
+    AS SELECT * FROM cargo.deals
+
+CREATE MATERIALIZED VIEW public.aggregate
+    AS SELECT * FROM cargo.aggregates
+
+CREATE MATERIALIZED VIEW public.aggregate_entry
+    AS SELECT * FROM cargo.aggregate_entries
+
+-- -- Later:
+-- REFRESH MATERIALIZED VIEW public.deal
+-- REFRESH MATERIALIZED VIEW public.aggregate
+-- REFRESH MATERIALIZED VIEW public.aggregate_entry

--- a/packages/db/tables.sql
+++ b/packages/db/tables.sql
@@ -29,8 +29,8 @@ CREATE TABLE IF NOT EXISTS nft_storage.user (
   github TEXT,
   email TEXT NOT NULL,
   public_address TEXT NOT NULL UNIQUE,
-  inserted_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL,
-  updated_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL
+  inserted_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS nft_storage.auth_key (
@@ -38,16 +38,16 @@ CREATE TABLE IF NOT EXISTS nft_storage.auth_key (
   name TEXT NOT NULL,
   secret TEXT NOT NULL,
   user_id TEXT NOT NULL REFERENCES user ( id ),
-  inserted_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL,
-  updated_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL
+  inserted_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS nft_storage.content (
   -- normalized base32 v1
   cid TEXT PRIMARY KEY,
   dag_size BIGINT,
-  inserted_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL,
-  updated_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL
+  inserted_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS nft_storage.pin (
@@ -55,8 +55,8 @@ CREATE TABLE IF NOT EXISTS nft_storage.pin (
   status pin_status NOT NULL,
   content_cid TEXT NOT NULL REFERENCES content ( cid ),
   service nft_storage.service NOT NULL,
-  inserted_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL,
-  updated_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL,
+  inserted_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
   UNIQUE (content_cid, service)
 );
 
@@ -64,8 +64,8 @@ CREATE TABLE IF NOT EXISTS nft_storage.upload (
   id BIGSERIAL PRIMARY KEY,
   user_id TEXT NOT NULL REFERENCES user ( id ),
   auth_key_id BIGINT REFERENCES auth_key ( id ),
-  source_cid text NOT NULL,
-  content_cid text NOT NULL REFERENCES content ( cid ),
+  source_cid TEXT NOT NULL,
+  content_cid TEXT NOT NULL REFERENCES content ( cid ),
   name TEXT,
   type nft_storage.upload_type NOT NULL,
   -- MIME type of the upload data as sent in the request.
@@ -73,7 +73,7 @@ CREATE TABLE IF NOT EXISTS nft_storage.upload (
   files jsonb,
   origins jsonb,
   meta jsonb,
-  inserted_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL,
-  updated_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL,
-  deleted_at timestamp with time zone DEFAULT timezone('utc'::text, now())
+  inserted_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
+  deleted_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now())
 );

--- a/packages/db/tables.sql
+++ b/packages/db/tables.sql
@@ -15,13 +15,15 @@ CREATE TYPE nft_storage.service AS ENUM (
 CREATE TYPE nft_storage.upload_type AS ENUM (
   'Car',
   'Blob',
-  'Multipart'
+  'Multipart', 
+  'Remote',
+  'NFT'
 );
 
 CREATE TABLE IF NOT EXISTS nft_storage.user (
   id BIGSERIAL PRIMARY KEY,
-  issuer TEXT,
-  sub TEXT,
+  magic_link_id TEXT,
+  github_id TEXT,
   name TEXT NOT NULL,
   picture TEXT,
   github TEXT,
@@ -66,6 +68,8 @@ CREATE TABLE IF NOT EXISTS nft_storage.upload (
   content_cid text NOT NULL REFERENCES content ( cid ),
   name TEXT,
   type nft_storage.upload_type NOT NULL,
+  -- MIME type of the upload data as sent in the request.
+  mime_type TEXT,
   files jsonb,
   origins jsonb,
   meta jsonb,

--- a/packages/db/tables.sql
+++ b/packages/db/tables.sql
@@ -1,24 +1,24 @@
-CREATE SCHEMA nftstorage;
+CREATE SCHEMA nft_storage;
 
-CREATE TYPE nftstorage.pin_status AS ENUM (
+CREATE TYPE nft_storage.pin_status AS ENUM (
   'Queued',
   'Pinning',
   'Pinned',
   'Failed'
 );
 
-CREATE TYPE nftstorage.service AS ENUM (
+CREATE TYPE nft_storage.service AS ENUM (
   'Pinata',
   'IpfsCluster'
 );
 
-CREATE TYPE nftstorage.upload_type AS ENUM (
+CREATE TYPE nft_storage.upload_type AS ENUM (
   'Car',
   'Blob',
   'Multipart'
 );
 
-CREATE TABLE IF NOT EXISTS nftstorage.user (
+CREATE TABLE IF NOT EXISTS nft_storage.user (
   id BIGSERIAL PRIMARY KEY,
   issuer TEXT,
   sub TEXT,
@@ -31,7 +31,7 @@ CREATE TABLE IF NOT EXISTS nftstorage.user (
   updated_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS nftstorage.auth_key (
+CREATE TABLE IF NOT EXISTS nft_storage.auth_key (
   id BIGSERIAL PRIMARY KEY,
   name TEXT NOT NULL,
   secret TEXT NOT NULL,
@@ -40,7 +40,7 @@ CREATE TABLE IF NOT EXISTS nftstorage.auth_key (
   updated_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS nftstorage.content (
+CREATE TABLE IF NOT EXISTS nft_storage.content (
   -- normalized base32 v1
   cid TEXT PRIMARY KEY,
   dag_size BIGINT,
@@ -48,24 +48,24 @@ CREATE TABLE IF NOT EXISTS nftstorage.content (
   updated_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS nftstorage.pin (
+CREATE TABLE IF NOT EXISTS nft_storage.pin (
   id BIGSERIAL PRIMARY KEY,
   status pin_status NOT NULL,
   content_cid TEXT NOT NULL REFERENCES content ( cid ),
-  service nftstorage.service NOT NULL,
+  service nft_storage.service NOT NULL,
   inserted_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL,
   updated_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL,
   UNIQUE (content_cid, service)
 );
 
-CREATE TABLE IF NOT EXISTS nftstorage.upload (
+CREATE TABLE IF NOT EXISTS nft_storage.upload (
   id BIGSERIAL PRIMARY KEY,
   user_id TEXT NOT NULL REFERENCES user ( id ),
   auth_key_id BIGINT REFERENCES auth_key ( id ),
   source_cid text NOT NULL,
   content_cid text NOT NULL REFERENCES content ( cid ),
   name TEXT,
-  type nftstorage.upload_type NOT NULL,
+  type nft_storage.upload_type NOT NULL,
   files jsonb,
   origins jsonb,
   meta jsonb,

--- a/packages/db/tables.sql
+++ b/packages/db/tables.sql
@@ -1,18 +1,16 @@
-CREATE SCHEMA nft_storage;
-
-CREATE TYPE nft_storage.pin_status AS ENUM (
+CREATE TYPE public.pin_status AS ENUM (
   'Queued',
   'Pinning',
   'Pinned',
   'Failed'
 );
 
-CREATE TYPE nft_storage.service AS ENUM (
+CREATE TYPE public.service AS ENUM (
   'Pinata',
   'IpfsCluster'
 );
 
-CREATE TYPE nft_storage.upload_type AS ENUM (
+CREATE TYPE public.upload_type AS ENUM (
   'Car',
   'Blob',
   'Multipart', 
@@ -20,7 +18,7 @@ CREATE TYPE nft_storage.upload_type AS ENUM (
   'NFT'
 );
 
-CREATE TABLE IF NOT EXISTS nft_storage.user (
+CREATE TABLE IF NOT EXISTS public.user (
   id BIGSERIAL PRIMARY KEY,
   magic_link_id TEXT,
   github_id TEXT,
@@ -33,7 +31,7 @@ CREATE TABLE IF NOT EXISTS nft_storage.user (
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS nft_storage.auth_key (
+CREATE TABLE IF NOT EXISTS public.auth_key (
   id BIGSERIAL PRIMARY KEY,
   name TEXT NOT NULL,
   secret TEXT NOT NULL,
@@ -42,7 +40,7 @@ CREATE TABLE IF NOT EXISTS nft_storage.auth_key (
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS nft_storage.content (
+CREATE TABLE IF NOT EXISTS public.content (
   -- normalized base32 v1
   cid TEXT PRIMARY KEY,
   dag_size BIGINT,
@@ -50,24 +48,24 @@ CREATE TABLE IF NOT EXISTS nft_storage.content (
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS nft_storage.pin (
+CREATE TABLE IF NOT EXISTS public.pin (
   id BIGSERIAL PRIMARY KEY,
   status pin_status NOT NULL,
   content_cid TEXT NOT NULL REFERENCES content ( cid ),
-  service nft_storage.service NOT NULL,
+  service public.service NOT NULL,
   inserted_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
   UNIQUE (content_cid, service)
 );
 
-CREATE TABLE IF NOT EXISTS nft_storage.upload (
+CREATE TABLE IF NOT EXISTS public.upload (
   id BIGSERIAL PRIMARY KEY,
   user_id TEXT NOT NULL REFERENCES user ( id ),
   auth_key_id BIGINT REFERENCES auth_key ( id ),
   source_cid TEXT NOT NULL,
   content_cid TEXT NOT NULL REFERENCES content ( cid ),
   name TEXT,
-  type nft_storage.upload_type NOT NULL,
+  type public.upload_type NOT NULL,
   -- MIME type of the upload data as sent in the request.
   mime_type TEXT,
   files jsonb,

--- a/packages/db/tables.sql
+++ b/packages/db/tables.sql
@@ -1,0 +1,75 @@
+CREATE SCHEMA nftstorage;
+
+CREATE TYPE nftstorage.pin_status AS ENUM (
+  'Queued',
+  'Pinning',
+  'Pinned',
+  'Failed'
+);
+
+CREATE TYPE nftstorage.service AS ENUM (
+  'Pinata',
+  'IpfsCluster'
+);
+
+CREATE TYPE nftstorage.upload_type AS ENUM (
+  'Car',
+  'Blob',
+  'Multipart'
+);
+
+CREATE TABLE IF NOT EXISTS nftstorage.user (
+  id BIGSERIAL PRIMARY KEY,
+  issuer TEXT,
+  sub TEXT,
+  name TEXT NOT NULL,
+  picture TEXT,
+  github TEXT,
+  email TEXT NOT NULL,
+  public_address TEXT NOT NULL UNIQUE,
+  inserted_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL,
+  updated_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS nftstorage.auth_key (
+  id BIGSERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  secret TEXT NOT NULL,
+  user_id TEXT NOT NULL REFERENCES user ( id ),
+  inserted_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL,
+  updated_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS nftstorage.content (
+  -- normalized base32 v1
+  cid TEXT PRIMARY KEY,
+  dag_size BIGINT,
+  inserted_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL,
+  updated_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS nftstorage.pin (
+  id BIGSERIAL PRIMARY KEY,
+  status pin_status NOT NULL,
+  content_cid TEXT NOT NULL REFERENCES content ( cid ),
+  service nftstorage.service NOT NULL,
+  inserted_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL,
+  updated_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL,
+  UNIQUE (content_cid, service)
+);
+
+CREATE TABLE IF NOT EXISTS nftstorage.upload (
+  id BIGSERIAL PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES user ( id ),
+  auth_key_id BIGINT REFERENCES auth_key ( id ),
+  source_cid text NOT NULL,
+  content_cid text NOT NULL REFERENCES content ( cid ),
+  name TEXT,
+  type nftstorage.upload_type NOT NULL,
+  files jsonb,
+  origins jsonb,
+  meta jsonb,
+  inserted_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL,
+  updated_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL,
+  deleted_at timestamp with time zone DEFAULT timezone('utc'::text, now())
+);

--- a/packages/db/tables.sql
+++ b/packages/db/tables.sql
@@ -35,7 +35,7 @@ CREATE TABLE IF NOT EXISTS public.auth_key (
   id BIGSERIAL PRIMARY KEY,
   name TEXT NOT NULL,
   secret TEXT NOT NULL,
-  user_id TEXT NOT NULL REFERENCES user ( id ),
+  user_id BIGINT NOT NULL REFERENCES public.user ( id ),
   inserted_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
 );
@@ -51,7 +51,7 @@ CREATE TABLE IF NOT EXISTS public.content (
 CREATE TABLE IF NOT EXISTS public.pin (
   id BIGSERIAL PRIMARY KEY,
   status pin_status NOT NULL,
-  content_cid TEXT NOT NULL REFERENCES content ( cid ),
+  content_cid TEXT NOT NULL REFERENCES public.content ( cid ),
   service public.service NOT NULL,
   inserted_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
@@ -60,10 +60,10 @@ CREATE TABLE IF NOT EXISTS public.pin (
 
 CREATE TABLE IF NOT EXISTS public.upload (
   id BIGSERIAL PRIMARY KEY,
-  user_id TEXT NOT NULL REFERENCES user ( id ),
-  auth_key_id BIGINT REFERENCES auth_key ( id ),
+  user_id BIGINT NOT NULL REFERENCES public.user ( id ),
+  auth_key_id BIGINT REFERENCES public.auth_key ( id ),
   source_cid TEXT NOT NULL,
-  content_cid TEXT NOT NULL REFERENCES content ( cid ),
+  content_cid TEXT NOT NULL REFERENCES public.content ( cid ),
   name TEXT,
   type public.upload_type NOT NULL,
   -- MIME type of the upload data as sent in the request.


### PR DESCRIPTION
I've taken the schema from https://github.com/ipfs-shipyard/nft.storage/pull/263 with the following changes:

* Primary keys are called `id` except where we're using domain data as the primary key (currently only `cid` in content).
* Use shortened primary key definition to use `BIGSERIAL` for enhanced readability.
* ~~Added `nft_storage` schema.~~
* Renamed `account` -> `user`.
* Make `issuer` NOT the primary key on `user`, added `id` column for primary and referenced it from other tables.
* Change `user.issuer` to `user.magic_link_id` and `user.sub` to `user.github_id`.
* Prefixed foreign keys with (complete) referenced table name where appropriate.
* Renamed `cid` in the `upload` table to `source_cid` so more obvious it is the given/original/provided/source CID.
* Added the `deleted_at` column to `upload` (and had to remove the `UNIQUE` constraint because of it).
* Consistent enums capitalization to match web3.storage and niftysave.
* Added `upload_type` enum.
* Added `mime_type` text field to `upload`.
* Renamed `content.size` to `content.dag_size` for consistency with web3.storage.