### PR TITLE
fix link to examples directory in client docs

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -46,12 +46,14 @@ console.log(metadata.url)
 // ipfs://bafyreib4pff766vhpbxbhjbqqnsh5emeznvujayjj4z2iu533cprgbz23m/metadata.json
 ```
 
-For more examples please see the [API documentation](https://ipfs-shipyard.github.io/nft.storage/client/) or the [examples directory](examples).
+For more examples please see the [API documentation](https://ipfs-shipyard.github.io/nft.storage/client/) or the [examples directory in the project repository][examples directory], which contains sample projects for both [browsers][examples.browser] and [node.js][examples.node].
 
 [raw http api]: https://nft.storage/#api-docs
 [node.js]: https://nodejs.org/
 [api documentation]: https://ipfs-shipyard.github.io/nft.storage/client/
 [examples directory]: https://github.com/ipfs-shipyard/nft.storage/tree/main/packages/client/examples
+[examples.node]: https://github.com/ipfs-shipyard/nft.storage/tree/main/packages/client/examples/node.js
+[examples.browser]: https://github.com/ipfs-shipyard/nft.storage/tree/main/packages/client/examples/browser
 [ci.icon]: https://github.com/ipfs-shipyard/nft.storage/actions/workflows/client.yml/badge.svg
 [version.icon]: https://img.shields.io/npm/v/nft.storage.svg
 [package.url]: https://npmjs.org/package/nft.storage


### PR DESCRIPTION
Fixes the examples link, and adds direct links to the node and browser subdirs. Closes #396 