### PR TITLE
chore: setup countly analytics

### DIFF
--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -165,3 +165,31 @@ CLUSTER_API_URL = "https://nft.storage.ipfscluster.io/api/"
 CLUSTER_IPFS_PROXY_API_URL = ""
 CLUSTER_ADDRS = ""
 DATABASE_URL = "http://localhost:8000"
+
+[env.ze]
+type = "webpack"
+name = "nft-storage-ze"
+account_id = "9357c50891f315d3c8a84e87ee47f740"
+workers_dev = true
+usage_model = ""
+route = ""
+zone_id = ""
+kv_namespaces = [
+    { binding = "USERS", preview_id = "ae5de1d8a7b24a7380bcf152d0a34405", id = "ae5de1d8a7b24a7380bcf152d0a34405" },
+    { binding = "NFTS", preview_id = "e151334b3ca14ba381a5eec9c0143e94", id = "e151334b3ca14ba381a5eec9c0143e94" },
+    { binding = "NFTS_IDX", preview_id = "8eb6bf97cfa243ab9bebe5dcb61233dc", id = "8eb6bf97cfa243ab9bebe5dcb61233dc" },
+    { binding = "DEALS", preview_id = "653d8a2c419843f18b9092fb2cc090dd", id = "653d8a2c419843f18b9092fb2cc090dd" },
+    { binding = "METRICS", preview_id = "dae53a615e7741d2a5d89a601e5b4c8d", id = "dae53a615e7741d2a5d89a601e5b4c8d" },
+    { binding = "PINS", preview_id = "a2fe6ea3f15d42deb208d482be50cc01", id = "a2fe6ea3f15d42deb208d482be50cc01" },
+    { binding = "FOLLOWUPS", preview_id = "6b8fd71bbbd241428585a91fb540519d", id = "6b8fd71bbbd241428585a91fb540519d" },
+    { binding = "PINATA_QUEUE", preview_id = "fba21c792337417e85296320a0ae58e4", id = "fba21c792337417e85296320a0ae58e4" }
+]
+
+
+[env.ze.vars]
+ENV = "dev"
+DEBUG = "*"
+CLUSTER_API_URL = "https://ze-cluster-api-nft-storage.loca.lt"
+CLUSTER_IPFS_PROXY_API_URL = "https://ze-ipfs-proxy-api-nft-storage.loca.lt"
+CLUSTER_ADDRS = ""
+DATABASE_URL = "http://localhost:8000"

--- a/packages/website/components/button.js
+++ b/packages/website/components/button.js
@@ -1,8 +1,16 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import Link from 'next/link'
 import clsx from 'clsx'
 
+import countly from '../lib/countly'
+
 /**
+ * @typedef {Object} TrackingProp
+ * @prop {string} ui UI section id. One of countly.ui.
+ * @prop {string} [action] Action id. used to uniquely identify an action within a ui section.
+ * @prop {string} [event] Custom event name to be used instead of the default CTA_LINK_CLICK.
+ * @prop {Object} [data] Extra data to send to countly.
+ *
  * @typedef {Object} ButtonProps
  * @prop {string} [id]
  * @prop {string} [wrapperClassName]
@@ -13,6 +21,8 @@ import clsx from 'clsx'
  * @prop {React.ReactChildren | string | React.ReactElement} children
  * @prop {boolean} [disabled]
  * @prop {boolean} [small]
+ * @prop {string} [id]
+ * @prop {TrackingProp} [tracking] Tracking data to send to countly on button click
  */
 
 /**
@@ -30,7 +40,25 @@ export default function Button({
   children,
   disabled = false,
   small = false,
+  tracking,
 }) {
+  const onClickHandler = useCallback(
+    (event) => {
+      tracking &&
+        countly.trackEvent(tracking.event || countly.events.CTA_LINK_CLICK, {
+          ui: tracking.ui,
+          action: tracking.action,
+          link:
+            typeof href === 'string'
+              ? href
+              : (href?.pathname || '') + (href?.hash || ''),
+          ...(tracking.data || {}),
+        })
+      onClick && onClick(event)
+    },
+    [tracking, onClick, href]
+  )
+
   wrapperClassName = clsx(
     'dib',
     'bg-nsgray',
@@ -59,7 +87,7 @@ export default function Button({
         className
       )}
       style={btnStyle}
-      onClick={onClick}
+      onClick={onClickHandler}
       disabled={disabled}
       id={id}
     >

--- a/packages/website/components/footer.js
+++ b/packages/website/components/footer.js
@@ -1,5 +1,16 @@
+import { useCallback } from 'react'
 import Link from 'next/link'
+
+import countly from '../lib/countly'
+
 export default function Footer() {
+  const onLinkClick = useCallback((event) => {
+    countly.trackCustomLinkClick(
+      countly.events.LINK_CLICK_FOOTER,
+      event.currentTarget
+    )
+  }, [])
+
   return (
     <footer className="bg-black db db-m flex-ns items-center justify-between f7 white pv3 ph5">
       <div>
@@ -8,6 +19,7 @@ export default function Footer() {
           <a
             href="https://protocol.ai/"
             className="nspink underline-hover no-underline"
+            onClick={onLinkClick}
           >
             Protocol Labs
           </a>
@@ -20,6 +32,7 @@ export default function Footer() {
             className="nspink no-underline underline-hover v-mid"
             target="_blank"
             rel="noreferrer"
+            onClick={onLinkClick}
           >
             Status
           </a>
@@ -27,7 +40,10 @@ export default function Footer() {
         <Dot />
         <span className="db db-m dib-ns mv3">
           <Link href="/terms">
-            <a className="nspink no-underline underline-hover v-mid">
+            <a
+              className="nspink no-underline underline-hover v-mid"
+              onClick={onLinkClick}
+            >
               Terms of Service
             </a>
           </Link>
@@ -38,6 +54,7 @@ export default function Footer() {
           <a
             href="https://github.com/ipfs-shipyard/nft.storage/issues/new"
             className="nspink underline-hover no-underline"
+            onClick={onLinkClick}
           >
             Open an Issue
           </a>

--- a/packages/website/components/hero.js
+++ b/packages/website/components/hero.js
@@ -1,3 +1,4 @@
+import countly from '../lib/countly'
 import Button from './button.js'
 
 const crossStyle = {
@@ -73,6 +74,7 @@ export default function Hero() {
             <Button
               wrapperClassName="mh3 mb3"
               href="#getting-started"
+              tracking={{ ui: countly.ui.HOME_HERO, action: 'Get Started' }}
             >
               Get Started
             </Button>

--- a/packages/website/lib/countly.js
+++ b/packages/website/lib/countly.js
@@ -1,0 +1,132 @@
+import countly from 'countly-sdk-web'
+
+const config = {
+  key: process.env.NEXT_PUBLIC_COUNTLY_KEY,
+  url: process.env.NEXT_PUBLIC_COUNTLY_URL,
+}
+
+/** @constant */
+export const events = {
+  LINK_CLICK_NAVBAR: 'linkClickNavbar',
+  LINK_CLICK_FOOTER: 'linkClickFooter',
+  // Used for CTAs that are only linking to other pages/resources
+  CTA_LINK_CLICK: 'ctaLinkClick',
+  // Other custom action events
+  LOGIN_CLICK: 'loginClick',
+  LOGOUT_CLICK: 'logoutClick',
+  FILE_UPLOAD_CLICK: 'fileUploadClick',
+  FILE_DELETE_CLICK: 'fileDeleteClick',
+  FILES_NAVIGATION_CLICK: 'filesNavigationClick',
+  TOKEN_CREATE: 'tokenCreate',
+  TOKEN_COPY: 'tokenCopy',
+  TOKEN_DELETE: 'tokenDelete',
+  NOT_FOUND: 'notFound',
+}
+
+/** @constant */
+export const ui = {
+  HOME_HERO: 'home/hero',
+  HOME_GET_STARTED: 'home/get-started',
+  NAVBAR: 'navbar',
+  LOGIN: 'login',
+  FILES: 'files',
+  NEW_FILE: 'new-file',
+  NEW_TOKEN: 'new-token',
+  TOKENS: 'tokens',
+}
+
+/**
+ * Initialize countly analytics object
+ */
+export function init() {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  if (ready) {
+    return
+  }
+
+  if (!config.key || !config.url) {
+    console.warn('[lib/countly]', 'Countly config not found.')
+
+    return
+  }
+
+  countly.init({ app_key: config.key, url: config.url, debug: false })
+
+  countly.track_sessions()
+  countly.track_pageview()
+  countly.track_clicks()
+  countly.track_links()
+  countly.track_scrolls()
+
+  ready = true
+}
+
+/**
+ * Track an event to countly with custom data
+ *
+ * @param {string} event Event name to be sent to countly.
+ * @param {Object} [segmentation] Custom data object to be used as segmentation data in countly.
+ */
+export function trackEvent(event, segmentation = {}) {
+  if (!ready) {
+    init()
+  }
+
+  ready &&
+    countly.add_event({
+      key: event,
+      segmentation: {
+        path: location.pathname,
+        ...segmentation,
+      },
+    })
+}
+
+/**
+ * Track page view to countly.
+ *
+ * @param {string} [path] Page route to track. Defaults to window.location.pathname if not provided.
+ */
+export function trackPageView(path) {
+  if (!ready) {
+    init()
+  }
+
+  ready && countly.track_pageview(path)
+}
+
+/**
+ * Track custom link click.
+ * @param {string} event Event name to be sent to countly.
+ * @param {HTMLLinkElement} target DOM element target of the clicked link.
+ * @param {Object} data Extra data to be sent to countly
+ */
+export function trackCustomLinkClick(event, target, data = {}) {
+  if (!ready) {
+    init()
+  }
+
+  ready &&
+    trackEvent(event, {
+      link: target.href.includes(location.origin)
+        ? new URL(target.href).pathname + (new URL(target.href).hash || '')
+        : target.href,
+      text: target.innerText,
+      ...data,
+    })
+}
+
+export let ready = false
+
+export default {
+  events,
+  ui,
+  init,
+  trackEvent,
+  trackPageView,
+  trackCustomLinkClick,
+  ready,
+}

--- a/packages/website/lib/types.d.ts
+++ b/packages/website/lib/types.d.ts
@@ -1,0 +1,1 @@
+declare module 'countly-sdk-web'

--- a/packages/website/next.config.js
+++ b/packages/website/next.config.js
@@ -3,6 +3,11 @@ const { withSentryConfig } = require('@sentry/nextjs')
 const nextConfig = {
   trailingSlash: true,
   reactStrictMode: true,
+  exportPathMap: async function () {
+    return {
+      '/ipfs-404.html': { page: '/404' },
+    }
+  },
 }
 
 const SentryWebpackPluginOptions = {

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -14,8 +14,10 @@
     "@magic-ext/oauth": "^0.8.0",
     "bytes": "^3.1.0",
     "clsx": "^1.1.1",
+    "countly-sdk-web": "^20.11.3",
     "filesize": "^6.1.0",
     "ipfs-car": "0.4.3",
+    "isomorphic-form-data": "^2.0.0",
     "magic-sdk": "^4.2.1",
     "nft.storage": "^3.0.0",
     "react": "17.0.2",
@@ -23,7 +25,6 @@
     "react-if": "^4.0.1",
     "react-query": "^3.13.9",
     "swagger-ui-react": "^3.45.0",
-    "isomorphic-form-data": "^2.0.0",
     "tachyons": "^4.12.0"
   },
   "devDependencies": {

--- a/packages/website/pages/404.js
+++ b/packages/website/pages/404.js
@@ -1,0 +1,17 @@
+import { useEffect } from 'react'
+
+import countly from '../lib/countly'
+
+export default function Custom404() {
+  useEffect(() => {
+    countly.trackEvent(countly.events.NOT_FOUND, {
+      path: location.pathname,
+    })
+  }, [])
+
+  return (
+    <main className="flex items-center justify-between my-4 lg:my-32 layout-margins min-vh-100 ph3 ph5-ns">
+      <h1 className="">404 - Page Not Found</h1>
+    </main>
+  )
+}

--- a/packages/website/pages/_app.js
+++ b/packages/website/pages/_app.js
@@ -1,8 +1,12 @@
+import { useEffect } from 'react'
+import Router from 'next/router'
 import { ReactQueryDevtools } from 'react-query/devtools'
 import 'tachyons/css/tachyons.css'
 import '../styles/global.css'
 import { QueryClient, QueryClientProvider } from 'react-query'
 import Layout from '../components/layout.js'
+import countly from '../lib/countly'
+
 const queryClient = new QueryClient({
   defaultOptions: { queries: { staleTime: 60 * 1000 } },
 })
@@ -13,6 +17,13 @@ const queryClient = new QueryClient({
  * @param {any} props
  */
 export default function App({ Component, pageProps }) {
+  useEffect(() => {
+    countly.init()
+    Router.events.on('routeChangeComplete', (route) => {
+      countly.trackPageView(route)
+    })
+  }, [])
+
   return (
     <QueryClientProvider client={queryClient}>
       <Layout {...pageProps}>

--- a/packages/website/pages/files.js
+++ b/packages/website/pages/files.js
@@ -5,6 +5,7 @@ import { NFTStorage } from 'nft.storage'
 import Button from '../components/button.js'
 import Loading from '../components/loading'
 import { getNfts, getToken, API } from '../lib/api.js'
+import countly from '../lib/countly.js'
 import { When } from 'react-if'
 import { useRouter } from 'next/router'
 
@@ -103,6 +104,10 @@ export default function Files({ user }) {
                 }}
                 className="flex-none"
                 id="upload"
+                tracking={{
+                  ui: countly.ui.FILES,
+                  action: 'Upload File',
+                }}
               >
                 + Upload
               </Button>
@@ -157,6 +162,11 @@ export default function Files({ user }) {
                                   type="submit"
                                   disabled={Boolean(deleting)}
                                   id="delete-nft"
+                                  tracking={{
+                                    event: countly.events.FILE_DELETE_CLICK,
+                                    ui: countly.ui.FILES,
+                                    action: 'Delete File',
+                                  }}
                                 >
                                   {deleting === nft.cid
                                     ? 'Deleting...'
@@ -176,6 +186,11 @@ export default function Files({ user }) {
                       disabled={befores.length === 1}
                       onClick={handlePrevClick}
                       id="files-previous"
+                      tracking={{
+                        event: countly.events.FILES_NAVIGATION_CLICK,
+                        ui: countly.ui.FILES,
+                        action: 'Previous',
+                      }}
                     >
                       ← Previous
                     </Button>
@@ -185,6 +200,11 @@ export default function Files({ user }) {
                       disabled={nfts.length < limit}
                       onClick={handleNextClick}
                       id="files-next"
+                      tracking={{
+                        event: countly.events.FILES_NAVIGATION_CLICK,
+                        ui: countly.ui.FILES,
+                        action: 'Next',
+                      }}
                     >
                       Next →
                     </Button>

--- a/packages/website/pages/index.js
+++ b/packages/website/pages/index.js
@@ -1,3 +1,6 @@
+import { useCallback } from 'react'
+
+import countly from '../lib/countly.js'
 import Hero from '../components/hero.js'
 import HashLink from '../components/hashlink.js'
 import Step from '../components/step.js'
@@ -174,6 +177,16 @@ function About() {
 }
 
 function GettingStarted() {
+  const onClickHandler = useCallback((event) => {
+    countly.trackCustomLinkClick(
+      countly.events.CTA_LINK_CLICK,
+      event.currentTarget,
+      {
+        ui: countly.ui.HOME_GET_STARTED,
+      }
+    )
+  }, [])
+
   const jsEx = `import { NFTStorage, File } from 'nft.storage'
 
 const apiKey = 'YOUR_API_KEY'
@@ -205,7 +218,10 @@ console.log(metadata.url)
             <Step>1</Step>
             <p className="chicagoflf f3 mw6 center">
               <Link href="/login">
-                <a className="no-underline underline-hover nsnavy">
+                <a
+                  className="no-underline underline-hover nsnavy"
+                  onClick={onClickHandler}
+                >
                   Register an nft.storage account
                 </a>
               </Link>{' '}
@@ -223,7 +239,10 @@ console.log(metadata.url)
             <Step>2</Step>
             <p className="chicagoflf f3 mw6 center">
               <Link href="/manage">
-                <a className="no-underline underline-hover nsnavy">
+                <a
+                  className="no-underline underline-hover nsnavy"
+                  onClick={onClickHandler}
+                >
                   Create an API access key
                 </a>
               </Link>{' '}

--- a/packages/website/pages/login.js
+++ b/packages/website/pages/login.js
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import Router, { useRouter } from 'next/router'
 import { loginEmail, loginSocial } from '../lib/magic.js'
+import countly from '../lib/countly'
 import Button from '../components/button.js'
 import { useQueryClient } from 'react-query'
 
@@ -56,7 +57,16 @@ export default function Login() {
             className="input-reset ba b--black pa2 mb2 w5 center db"
           />
 
-          <Button type="submit" disabled={disabled} wrapperClassName="w5">
+          <Button
+            type="submit"
+            disabled={disabled}
+            wrapperClassName="w5"
+            tracking={{
+              event: countly.events.LOGIN_CLICK,
+              ui: countly.ui.LOGIN,
+              action: 'Sign Up / Login',
+            }}
+          >
             Sign Up / Login
           </Button>
 
@@ -69,6 +79,11 @@ export default function Login() {
             onClick={() => {
               setIsRedirecting(true)
               loginSocial('github', version)
+            }}
+            tracking={{
+              event: countly.events.LOGIN_CLICK,
+              ui: countly.ui.LOGIN,
+              action: 'Github',
             }}
           >
             {isRedirecting ? 'Redirecting...' : 'Github'}

--- a/packages/website/pages/manage.js
+++ b/packages/website/pages/manage.js
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { If, Then, Else, When } from 'react-if'
 import Button from '../components/button.js'
 import { deleteToken, getTokens } from '../lib/api'
+import countly from '../lib/countly.js'
 import { useQuery, useQueryClient } from 'react-query'
 import Loading from '../components/loading.js'
 import { useRouter } from 'next/router'
@@ -100,6 +101,7 @@ export default function ManageKeys({ user }) {
                 }}
                 className="flex-none"
                 id="new-key"
+                tracking={{ ui: countly.ui.TOKENS, action: 'New API Token' }}
               >
                 + New Key
               </Button>
@@ -132,6 +134,10 @@ export default function ManageKeys({ user }) {
                             className="bg-white black"
                             type="submit"
                             id="copy-key"
+                            tracking={{
+                              event: countly.events.TOKEN_COPY,
+                              ui: countly.ui.TOKENS,
+                            }}
                           >
                             {copied === t[1] ? 'Copied!' : 'Copy'}
                           </Button>
@@ -150,6 +156,10 @@ export default function ManageKeys({ user }) {
                             type="submit"
                             disabled={Boolean(deleting)}
                             id={`delete-key-${t[0]}`}
+                            tracking={{
+                              event: countly.events.TOKEN_DELETE,
+                              ui: countly.ui.TOKENS,
+                            }}
                           >
                             {deleting ===
                             (version === '1' ? `${t[2]}` + '' : t[0])

--- a/packages/website/pages/new-file.js
+++ b/packages/website/pages/new-file.js
@@ -1,4 +1,5 @@
 import { getToken, API } from '../lib/api'
+import countly from '../lib/countly.js'
 import { useRouter } from 'next/router'
 import { NFTStorage } from 'nft.storage'
 import { packToBlob } from 'ipfs-car/pack/blob'
@@ -149,6 +150,10 @@ export default function NewFile() {
                 type="submit"
                 disabled={uploading}
                 id="upload-file"
+                tracking={{
+                  event: countly.events.FILE_UPLOAD_CLICK,
+                  ui: countly.ui.NEW_FILE,
+                }}
               >
                 {uploading
                   ? `Uploading...${

--- a/packages/website/pages/new-key.js
+++ b/packages/website/pages/new-key.js
@@ -4,6 +4,7 @@ import { useQueryClient } from 'react-query'
 import Box from '../components/box.js'
 import Button from '../components/button.js'
 import { createToken } from '../lib/api.js'
+import countly from '../lib/countly.js'
 
 /**
  * Static Props
@@ -77,6 +78,10 @@ export default function NewKey() {
                 type="submit"
                 disabled={creating}
                 id="create-new-key"
+                tracking={{
+                  event: countly.events.TOKEN_CREATE,
+                  ui: countly.ui.NEW_TOKEN,
+                }}
               >
                 {creating ? 'Creating...' : 'Create'}
               </Button>


### PR DESCRIPTION
This PR adds countly analytics for tracking usage of the website.

I used the same setup from Web3 Storage.
You can check the new Countly app and dashboard for the stats generated while developing this.

TODO:

- [x] Setup the two new env vars on production build (`NEXT_PUBLIC_COUNTLY_KEY` and `NEXT_PUBLIC_COUNTLY_URL`)

Closes #360 