### PR TITLE
fix: min, max and default limits for v1 list endpoints

### DIFF
--- a/packages/api/src/routes-v1/nfts-list.js
+++ b/packages/api/src/routes-v1/nfts-list.js
@@ -1,30 +1,38 @@
+import { Validator } from '@cfworker/json-schema'
 import { JSONResponse } from '../utils/json-response.js'
 import { validate } from '../utils/auth-v1.js'
 import { toNFTResponse } from '../utils/db-transforms.js'
+import { HTTPError } from '../errors.js'
+
+const DEFAULT_LIMIT = 10
+const MAX_LIMIT = 1000
+
+const validator = new Validator({
+  type: 'object',
+  required: ['before', 'limit'],
+  properties: {
+    before: { type: 'string', format: 'date-time' },
+    limit: { type: 'integer', minimum: 1, maximum: MAX_LIMIT },
+  },
+})
 
 /** @type {import('../utils/router.js').Handler} */
 export async function nftListV1(event, ctx) {
   const { user, db } = await validate(event, ctx)
-  const options = {
-    limit: 10,
-    before: new Date().toISOString(),
-  }
   const { searchParams } = new URL(event.request.url)
-
-  const limit = searchParams.get('limit')
-  if (limit) {
-    options.limit = parseInt(limit)
+  const options = {
+    limit: searchParams.get('limit')
+      ? Number(searchParams.get('limit'))
+      : DEFAULT_LIMIT,
+    before: searchParams.get('before') || new Date().toISOString(),
   }
 
-  const before = searchParams.get('before')
-  if (before) {
-    options.before = before
+  const result = validator.validate(options)
+  if (!result.valid) {
+    throw new HTTPError('invalid params', 400)
   }
 
-  const nfts = await db.listUploads(user.id, {
-    limit: options.limit,
-    before: options.before,
-  })
+  const nfts = await db.listUploads(user.id, options)
 
   return new JSONResponse({
     ok: true,

--- a/packages/api/src/routes-v1/pins-list.js
+++ b/packages/api/src/routes-v1/pins-list.js
@@ -1,9 +1,11 @@
-import * as cluster from '../cluster.js'
 import { validate } from '../utils/auth-v1.js'
 import { JSONResponse } from '../utils/json-response.js'
 import { Validator } from '@cfworker/json-schema'
 import { parseCidPinning } from '../utils/utils.js'
 import { toPinsResponse } from '../utils/db-transforms.js'
+
+const DEFAULT_LIMIT = 10
+const MAX_LIMIT = 1000
 
 /**
  * @typedef {import('../utils/db-client-types').ListUploadsOptions} ListUploadsOptions
@@ -71,7 +73,7 @@ const validator = new Validator({
     after: { type: 'string', format: 'date-time' },
     before: { type: 'string', format: 'date-time' },
     cid: { type: 'array', items: { type: 'string' } },
-    limit: { type: 'number' },
+    limit: { type: 'integer', minimum: 1, maximum: MAX_LIMIT },
     meta: { type: 'object' },
     match: {
       type: 'string',
@@ -141,8 +143,10 @@ function parseSearchParams(params) {
   }
 
   const limitParam = params.get('limit')
-  if (limitParam && !Number.isNaN(Number(limitParam))) {
+  if (limitParam) {
     out.limit = Number(limitParam)
+  } else {
+    out.limit = DEFAULT_LIMIT
   }
 
   const metaParam = params.get('meta')

--- a/packages/api/test/nfts-list-v1.spec.js
+++ b/packages/api/test/nfts-list-v1.spec.js
@@ -55,6 +55,7 @@ describe('V1 - List NFTs', () => {
 
     assert.ok(value.length === 1)
   })
+
   it('should list 0 nfts with date before any uploads', async () => {
     const date = new Date().toISOString()
     const client = await createClientWithUser()
@@ -98,5 +99,32 @@ describe('V1 - List NFTs', () => {
     const { ok, value } = await res.json()
 
     assert.ok(value.length === 10)
+  })
+
+  it('should validate the limit param', async () => {
+    const client = await createClientWithUser()
+
+    for (let i = 0; i < 10; i++) {
+      await client.client.createUpload({
+        account_id: client.userId,
+        content_cid: `bafy${i}`,
+        source_cid: `bafy${i}`,
+        type: 'Blob',
+      })
+    }
+    await delay(300)
+
+    const invalidLimits = [-1, 0, 1001, 'not-a-number', 1.138]
+
+    for (const limit of invalidLimits) {
+      const res = await fetch(`v1?limit=${limit}`, {
+        headers: { Authorization: `Bearer ${client.token}` },
+      })
+      assert.strictEqual(res.status, 400)
+
+      const { ok, error } = await res.json()
+      assert.strictEqual(ok, false)
+      assert.strictEqual(error.message, 'invalid params')
+    }
   })
 })


### PR DESCRIPTION
This PR adds minimum, maximum and default limits for v1 list endpoints.

The default is the same - 10. I upped the max from 100 to 1,000, which should be a non-breaking change. Minimum remains at 1...