### PR TITLE
feat: add new cluster enum value

### DIFF
--- a/packages/api/db/tables.sql
+++ b/packages/api/db/tables.sql
@@ -7,7 +7,7 @@ CREATE TYPE pin_status_type AS ENUM (
     );
 
 -- Pin Services Type
-CREATE TYPE service_type AS ENUM ('Pinata', 'IpfsCluster');
+CREATE TYPE service_type AS ENUM ('Pinata', 'IpfsCluster', 'IpfsCluster2');
 
 -- Upload Type
 CREATE TYPE upload_type AS ENUM (

--- a/packages/api/src/utils/db-client.js
+++ b/packages/api/src/utils/db-client.js
@@ -67,7 +67,7 @@ export class DBClient {
         pins: [
           {
             status: 'PinQueued',
-            service: 'IpfsCluster',
+            service: 'IpfsCluster2',
           },
           {
             status: 'PinQueued',
@@ -112,7 +112,7 @@ export class DBClient {
       .eq('content_cid', cid)
       .eq('account_id', userId)
       // @ts-ignore
-      .filter('content.pin.service', 'eq', 'IpfsCluster')
+      .filter('content.pin.service', 'in', '(IpfsCluster,IpfsCluster2)')
       .single()
 
     if (status === 406 || !upload) {
@@ -139,7 +139,7 @@ export class DBClient {
       .select(this.uploadQuery)
       .eq('account_id', userId)
       // @ts-ignore
-      .filter('content.pin.service', 'eq', 'IpfsCluster')
+      .filter('content.pin.service', 'in', '(IpfsCluster,IpfsCluster2)')
       .limit(opts.limit || 10)
       .order('inserted_at', { ascending: false })
 
@@ -236,7 +236,7 @@ export class DBClient {
         pins:pin(status, service)`
       )
       // @ts-ignore
-      .filter('pins.service', 'eq', 'IpfsCluster')
+      .filter('pins.service', 'in', '(IpfsCluster,IpfsCluster2)')
       .eq('cid', cid)
       .single()
 

--- a/packages/api/src/utils/db-types.d.ts
+++ b/packages/api/src/utils/db-types.d.ts
@@ -845,7 +845,7 @@ export interface definitions {
      * This is a Foreign Key to `content.cid`.<fk table='content' column='cid'/>
      */
     content_cid: string
-    service: 'Pinata' | 'IpfsCluster'
+    service: 'Pinata' | 'IpfsCluster' | 'IpfsCluster2'
     inserted_at: string
     updated_at: string
   }

--- a/packages/api/test/nfts-store-v1.spec.js
+++ b/packages/api/test/nfts-store-v1.spec.js
@@ -77,7 +77,7 @@ describe('V1 - /store', () => {
         content_cid:
           'bafyreicnwbboevx6g6fykitf4nebz2kqgkqz35qvlnlcgfulhrris66m6i',
         status: 'PinQueued',
-        service: 'IpfsCluster',
+        service: 'IpfsCluster2',
       },
       {
         content_cid:


### PR DESCRIPTION
Adds a new enum value for the new cluster we're switching to.

Do not merge until https://github.com/ipfs-shipyard/nft.storage/pull/464 is deployed.