### PR TITLE
feat: add prom metrics endpoint generated from postgres data

### DIFF
--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -21,6 +21,7 @@ import { login } from './routes/login.js'
 import { JSONResponse } from './utils/json-response.js'
 import { debug } from './utils/debug.js'
 import { getNFT } from './routes/get-nft.js'
+import { metrics as metricsV1 } from './routes-v1/metrics.js'
 import { tokensDeleteV1 } from './routes-v1/tokens-delete.js'
 import { tokensCreateV1 } from './routes-v1/tokens-create.js'
 import { tokensListV1 } from './routes-v1/tokens-list.js'
@@ -58,6 +59,7 @@ const r = new Router({
 
 // Monitoring
 r.add('get', '/metrics', withMode(metrics, READ_ONLY))
+r.add('get', '/v1/metrics', withMode(metricsV1, READ_ONLY))
 
 // CORS
 r.add('options', '*', cors)

--- a/packages/api/src/routes-v1/metrics.js
+++ b/packages/api/src/routes-v1/metrics.js
@@ -1,0 +1,100 @@
+import { secrets, database } from '../constants.js'
+import { DBClient } from '../utils/db-client.js'
+
+const db = new DBClient(database.url, secrets.database)
+
+export async function getUserMetrics() {
+  const query = db.client.from('account')
+  const res = await query.select('*', { head: true, count: 'exact' })
+  if (res.error) {
+    throw res.error
+  }
+  return { total: res.count }
+}
+
+export async function getNftMetrics() {
+  const types = ['Car', 'Blob', 'Multipart', 'Remote', 'Nft']
+  const totals = await Promise.all(
+    types.map(async (t) => {
+      const query = db.client.from('upload')
+      const res = await query
+        .select('*', { head: true, count: 'exact' })
+        .filter('type', 'eq', t)
+      if (res.error) {
+        throw res.error
+      }
+      return { [t]: res.count }
+    })
+  )
+  return { totals: Object.assign({}, ...totals) }
+}
+
+export async function getPinMetrics() {
+  const services = ['Pinata', 'IpfsCluster']
+  const statuses = ['PinQueued', 'Pinning', 'Pinned', 'PinError']
+  const totals = await Promise.all(
+    services.map(async (service) => {
+      const totals = await Promise.all(
+        statuses.map(async (status) => {
+          const query = db.client.from('pin')
+          const res = await query
+            .select('*', { head: true, count: 'exact' })
+            .filter('service', 'eq', service)
+            .filter('status', 'eq', status)
+          if (res.error) {
+            throw res.error
+          }
+          return { [status]: res.count }
+        })
+      )
+      return { [service]: Object.assign({}, ...totals) }
+    })
+  )
+  return { totals: Object.assign({}, ...totals) }
+}
+
+/**
+ * TODO: basic auth
+ */
+export async function metrics() {
+  return new Response(await exportPromMetrics())
+}
+
+/**
+ * Exports metrics in prometheus exposition format.
+ * https://prometheus.io/docs/instrumenting/exposition_formats/
+ * @returns {Promise<string>}
+ */
+async function exportPromMetrics() {
+  const [users, nfts, pins] = await Promise.all([
+    getUserMetrics(),
+    getNftMetrics(),
+    getPinMetrics(),
+  ])
+
+  return [
+    '# HELP nftstorage_users_total Total users registered.',
+    '# TYPE nftstorage_users_total counter',
+    `nftstorage_users_total ${users.total}`,
+
+    ...Object.entries(nfts.totals).map(([type, total]) =>
+      [
+        `# HELP nftstorage_uploads_total Total number of ${type} uploads.`,
+        '# TYPE nftstorage_uploads_total counter',
+        `nftstorage_uploads_total{type:"${type}"} ${total}`,
+      ].join('\n')
+    ),
+
+    ...Object.entries(pins.totals).map(([service, totals]) => {
+      return Object.entries(totals)
+        .map(([status, total]) =>
+          [
+            `# HELP nftstorage_pins_total Total number of ${service} pins that are ${status}.`,
+            '# TYPE nftstorage_pins_total counter',
+            `nftstorage_pins_total{service:"${service}",status:"${status}"} ${total}`,
+          ].join('\n')
+        )
+        .join('\n')
+    }),
+  ].join('\n')
+}

--- a/packages/api/src/routes-v1/metrics.js
+++ b/packages/api/src/routes-v1/metrics.js
@@ -4,7 +4,7 @@ import { DBClient } from '../utils/db-client.js'
 const db = new DBClient(database.url, secrets.database)
 
 export async function getUserMetrics() {
-  const query = db.client.from('account')
+  const query = db.client.from('user')
   const res = await query.select('*', { head: true, count: 'exact' })
   if (res.error) {
     throw res.error

--- a/packages/api/test/nfts-list-v1.spec.js
+++ b/packages/api/test/nfts-list-v1.spec.js
@@ -106,7 +106,7 @@ describe('V1 - List NFTs', () => {
 
     for (let i = 0; i < 10; i++) {
       await client.client.createUpload({
-        account_id: client.userId,
+        user_id: client.userId,
         content_cid: `bafy${i}`,
         source_cid: `bafy${i}`,
         type: 'Blob',

--- a/packages/tools/cf-sync/push-to-db.js
+++ b/packages/tools/cf-sync/push-to-db.js
@@ -67,7 +67,7 @@ export async function pushToDB(ctx, task) {
  * @param {Context} ctx
  * @param {Task} task
  * @param {definitions['auth_key'][]} keys
- * @param {definitions['account']} dbUser
+ * @param {definitions['user']} dbUser
  */
 async function nftByUser(issuer, sub, ctx, task, keys, dbUser) {
   const threshold = 20000
@@ -153,7 +153,7 @@ async function addNFTs(values, keys, ctx, dbUser) {
     const types = getMimeAndType(data.type)
     const parsedCID = parseCid(data.cid)
     uploadArray.push({
-      account_id: dbUser.id,
+      user_id: dbUser.id,
       key_id: authKey ? authKey.id : null,
       content_cid: parsedCID.contentCid,
       source_cid: parsedCID.sourceCid,


### PR DESCRIPTION
Not exporting byte totals anymore as these can come from dagcargo.

Have split upload totals out by type.

Have split pin totals by service and status (as opposed to just status).

Example output:

```
# HELP nftstorage_users_total Total users registered.
# TYPE nftstorage_users_total counter
nftstorage_users_total 1
# HELP nftstorage_uploads_total Total number of Car uploads.
# TYPE nftstorage_uploads_total counter
nftstorage_uploads_total{type:"Car"} 0
# HELP nftstorage_uploads_total Total number of Blob uploads.
# TYPE nftstorage_uploads_total counter
nftstorage_uploads_total{type:"Blob"} 0
# HELP nftstorage_uploads_total Total number of Multipart uploads.
# TYPE nftstorage_uploads_total counter
nftstorage_uploads_total{type:"Multipart"} 0
# HELP nftstorage_uploads_total Total number of Remote uploads.
# TYPE nftstorage_uploads_total counter
nftstorage_uploads_total{type:"Remote"} 0
# HELP nftstorage_uploads_total Total number of Nft uploads.
# TYPE nftstorage_uploads_total counter
nftstorage_uploads_total{type:"Nft"} 0
# HELP nftstorage_pins_total Total number of Pinata pins that are PinQueued.
# TYPE nftstorage_pins_total counter
nftstorage_pins_total{service:"Pinata",status:"PinQueued"} 0
# HELP nftstorage_pins_total Total number of Pinata pins that are Pinning.
# TYPE nftstorage_pins_total counter
nftstorage_pins_total{service:"Pinata",status:"Pinning"} 0
# HELP nftstorage_pins_total Total number of Pinata pins that are Pinned.
# TYPE nftstorage_pins_total counter
nftstorage_pins_total{service:"Pinata",status:"Pinned"} 0
# HELP nftstorage_pins_total Total number of Pinata pins that are PinError.
# TYPE nftstorage_pins_total counter
nftstorage_pins_total{service:"Pinata",status:"PinError"} 0
# HELP nftstorage_pins_total Total number of IpfsCluster pins that are PinQueued.
# TYPE nftstorage_pins_total counter
nftstorage_pins_total{service:"IpfsCluster",status:"PinQueued"} 0
# HELP nftstorage_pins_total Total number of IpfsCluster pins that are Pinning.
# TYPE nftstorage_pins_total counter
nftstorage_pins_total{service:"IpfsCluster",status:"Pinning"} 0
# HELP nftstorage_pins_total Total number of IpfsCluster pins that are Pinned.
# TYPE nftstorage_pins_total counter
nftstorage_pins_total{service:"IpfsCluster",status:"Pinned"} 0
# HELP nftstorage_pins_total Total number of IpfsCluster pins that are PinError.
# TYPE nftstorage_pins_total counter
nftstorage_pins_total{service:"IpfsCluster",status:"PinError"} 0
```