### PR TITLE
fix: nft-asset migration

### DIFF
--- a/packages/niftysave/src/migrate/nft-asset.js
+++ b/packages/niftysave/src/migrate/nft-asset.js
@@ -70,14 +70,9 @@ const insert = ({
  * @returns {Migration.Mutation}
  */
 export const mutation = (documents) => ({
-  insert_nft_asset: [
+  insert_nft_asset_view: [
     {
       objects: documents.map(insert),
-      // Ignore duplicates, just in case fauna's uniqness constrained has failed.
-      on_conflict: {
-        constraint: Migration.schema.nft_asset_constraint.nft_asset_pkey,
-        update_columns: [],
-      },
     },
     {
       affected_rows: true,


### PR DESCRIPTION
use view so that batch inserts would work. Works around https://github.com/hasura/graphql-engine/issues/4633