### PR TITLE
Fix: niftysave erc721 import migration

### DIFF
--- a/packages/niftysave/package.json
+++ b/packages/niftysave/package.json
@@ -12,7 +12,7 @@
     "analyze": "node ./src/analyze.js",
     "pin": "node ./src/pin.js",
     "migrate-content": "node ./src/migrate/content.js",
-    "migrate-erc721-import": "node ./src/migrate/erc721-import.js",
+    "migrate-erc721-import": "node ./src/migrate/erc721-import.js --batch-size 1",
     "migrate-erc721-import-by-nft": "node ./src/migrate/erc721-import-by-nft.js",
     "migrate-nft-metadata": "node ./src/migrate/nft-metadata.js",
     "migrate-blockchain-block": "node ./src/migrate/blockchain-block.js",

--- a/packages/niftysave/src/migrate/erc721-import.js
+++ b/packages/niftysave/src/migrate/erc721-import.js
@@ -24,6 +24,13 @@ export const mutation = (documents) => ({
   insert_erc721_import: [
     {
       objects: documents.map(insert),
+      on_conflict: {
+        constraint:
+          Migration.schema.erc721_import_constraint.erc721_import_pkey,
+        update_columns: [
+          Migration.schema.erc721_import_update_column.updated_at,
+        ],
+      },
     },
     {
       affected_rows: true,


### PR DESCRIPTION
Disable batching for erc721-import table because fauna has many duplicates