### PR TITLE
feat: implement ingest_erc721_token endpoint

### DIFF
--- a/packages/database_v2/metadata/databases/default/functions/functions.yaml
+++ b/packages/database_v2/metadata/databases/default/functions/functions.yaml
@@ -1,3 +1,4 @@
 - "!include public_add_nft.yaml"
 - "!include public_add_nft_metadata.yaml"
 - "!include public_add_other_nft_resource.yaml"
+- "!include public_ingest_erc721_token.yaml"

--- a/packages/database_v2/metadata/databases/default/functions/public_ingest_erc721_token.yaml
+++ b/packages/database_v2/metadata/databases/default/functions/public_ingest_erc721_token.yaml
@@ -1,0 +1,3 @@
+function:
+  name: ingest_erc721_token
+  schema: public

--- a/packages/database_v2/metadata/databases/default/tables/public_nft_ownership.yaml
+++ b/packages/database_v2/metadata/databases/default/tables/public_nft_ownership.yaml
@@ -1,0 +1,3 @@
+table:
+  name: nft_ownership
+  schema: public

--- a/packages/database_v2/metadata/databases/default/tables/tables.yaml
+++ b/packages/database_v2/metadata/databases/default/tables/tables.yaml
@@ -8,6 +8,7 @@
 - "!include public_nft_asset_view.yaml"
 - "!include public_nft_metadata.yaml"
 - "!include public_nft_owner.yaml"
+- "!include public_nft_ownership.yaml"
 - "!include public_nfts_by_blockchain_blocks.yaml"
 - "!include public_niftysave_migration.yaml"
 - "!include public_other_nft_resources.yaml"

--- a/packages/database_v2/metadata/databases/default/tables/tables.yaml
+++ b/packages/database_v2/metadata/databases/default/tables/tables.yaml
@@ -8,7 +8,6 @@
 - "!include public_nft_asset_view.yaml"
 - "!include public_nft_metadata.yaml"
 - "!include public_nft_owner.yaml"
-- "!include public_nft_ownership.yaml"
 - "!include public_nfts_by_blockchain_blocks.yaml"
 - "!include public_niftysave_migration.yaml"
 - "!include public_other_nft_resources.yaml"

--- a/packages/database_v2/migrations/default/1633116387275_nft_ownership/down.sql
+++ b/packages/database_v2/migrations/default/1633116387275_nft_ownership/down.sql
@@ -1,0 +1,9 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- CREATE TABLE nft_ownership (
+--     nft_id TEXT NOT NULL,
+--     owner_id TEXT NOT NULL,
+--     block_number TEXT NOT NULL,
+--     updated_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
+--     inserted_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
+-- );

--- a/packages/database_v2/migrations/default/1633116387275_nft_ownership/up.sql
+++ b/packages/database_v2/migrations/default/1633116387275_nft_ownership/up.sql
@@ -3,5 +3,7 @@ CREATE TABLE nft_ownership (
     owner_id TEXT NOT NULL,
     block_number TEXT NOT NULL,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
-    inserted_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
+    inserted_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
+    
+    PRIMARY KEY (block_number, nft_id, owner_id)
 );

--- a/packages/database_v2/migrations/default/1633116387275_nft_ownership/up.sql
+++ b/packages/database_v2/migrations/default/1633116387275_nft_ownership/up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE nft_ownership (
+    nft_id TEXT NOT NULL,
+    owner_id TEXT NOT NULL,
+    block_number TEXT NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
+    inserted_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
+);

--- a/packages/database_v2/migrations/default/1633116816964_ingest_erc721_token/down.sql
+++ b/packages/database_v2/migrations/default/1633116816964_ingest_erc721_token/down.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION ingest_erc721_token;

--- a/packages/database_v2/migrations/default/1633116816964_ingest_erc721_token/up.sql
+++ b/packages/database_v2/migrations/default/1633116816964_ingest_erc721_token/up.sql
@@ -1,0 +1,74 @@
+CREATE FUNCTION ingest_erc721_token (
+-- Unique token identifier
+id nft.id % TYPE,
+-- ERC721 tokenID (unique within a contract space)
+token_id nft.token_id % TYPE,
+-- ERC721 tokenURI
+token_uri nft_asset.token_uri % TYPE,
+-- ERC721 mintTime
+mint_time nft.mint_time % TYPE,
+-- NFT Contract
+contract_id nft.contract_id % TYPE, contract_name blockchain_contract.name % TYPE, contract_symbol blockchain_contract.symbol % TYPE, contract_supports_eip721_metadata blockchain_contract.supports_eip721_metadata % TYPE,
+-- Block
+block_hash blockchain_block.hash % TYPE, block_number blockchain_block.number % TYPE,
+-- Owner
+owner_id nft_ownership.owner_id % TYPE,
+-- Timestamps
+updated_at nft.updated_at % TYPE DEFAULT timezone('utc'::text, now()), inserted_at nft.inserted_at % TYPE DEFAULT timezone('utc'::text, now()))
+  RETURNS SETOF nft
+  LANGUAGE plpgsql
+  AS $$
+DECLARE
+  token_uri_hash nft.token_uri_hash % TYPE;
+  nft_id nft.id % TYPE;
+BEGIN
+  nft_id := id;
+  -- Create a corresponding token_asset record. If one already
+  -- exists just update it's `update_at` timestamp.
+  INSERT INTO nft_asset (token_uri, ipfs_url, content_cid, status, status_text)
+    VALUES (token_uri, NULL, NULL, 'Queued', '')
+  ON CONFLICT ON CONSTRAINT nft_asset_pkey
+    DO UPDATE SET
+      updated_at = EXCLUDED.updated_at
+    RETURNING
+      nft_asset.token_uri_hash INTO token_uri_hash;
+  -- Record the block information if already exists just update the timestamp.
+  INSERT INTO blockchain_block (hash, number)
+    VALUES (block_hash, block_number)
+  ON CONFLICT ON CONSTRAINT blockchain_block_pkey
+    DO UPDATE SET
+      updated_at = EXCLUDED.updated_at;
+  -- Record contract information if already exists just update
+  -- the date.
+  INSERT INTO blockchain_contract (id, name, symbol, supports_eip721_metadata)
+    VALUES (contract_id, contract_name, contract_symbol, contract_supports_eip721_metadata)
+  ON CONFLICT ON CONSTRAINT blockchain_contract_pkey
+    DO UPDATE SET
+      updated_at = EXCLUDED.updated_at;
+  -- Record owner information
+  INSERT INTO nft_ownership (nft_id, owner_id, block_number)
+    VALUES (nft_id, owner_id, block_number)
+  ON CONFLICT ON CONSTRAINT nft_ownership_pkey
+    DO UPDATE SET
+      updated_at = EXCLUDED.updated_at;
+  -- Record nft
+  INSERT INTO nft (id, token_id, token_uri_hash, mint_time, contract_id, nft_owner_id)
+    VALUES (nft_id, token_id, token_uri_hash, mint_time, contract_id, owner_id)
+  ON CONFLICT ON CONSTRAINT nft_pkey
+    DO UPDATE SET
+      updated_at = EXCLUDED.updated_at, nft_owner_id = EXCLUDED.nft_owner_id;
+  -- Record nft to block association
+  INSERT INTO nfts_by_blockchain_blocks (blockchain_block_hash, nft_id)
+    VALUES (block_hash, nft_id)
+  ON CONFLICT ON CONSTRAINT nfts_by_blockchain_blocks_pkey
+    DO UPDATE SET
+      updated_at = EXCLUDED.updated_at;
+  RETURN QUERY
+  SELECT
+    *
+  FROM
+    nft
+  WHERE
+    nft.id = nft_id;
+END;
+$$;


### PR DESCRIPTION
This change introduces `ingest_erc721_token` SQL function and corresponding GraphQL mutation as a replacement of former [`importERC721`](https://github.com/ipfs-shipyard/nft.storage/blob/47634bf6e49710846fff1fc4235b7ec7f14918c8/packages/database/fauna/resources/Function/importERC721.fql). Unlike former it does not work with batches instead it ingests one nft at a time.

This change deprecate `erc721_import` and `erc721_import_by_nft` tables. Going forward [`ingest.js`](https://github.com/ipfs-shipyard/nft.storage/blob/47634bf6e49710846fff1fc4235b7ec7f14918c8/packages/niftysave/src/ingest.js) task will:

1. Obtain current cursor by taking `nft.id` with largest `inserted_at`.
2. Will enqueue pulled `nfts` from the subgraph to writable end of transform stream.
3. Have concurrent task that pulls each nft record from the readable end of transform stream and write it to db via `ingest_erc721_token`.