### PR TITLE
feat: add new cluster enum and nothing else

### DIFF
--- a/packages/api/db/tables.sql
+++ b/packages/api/db/tables.sql
@@ -7,7 +7,7 @@ CREATE TYPE pin_status_type AS ENUM (
     );
 
 -- Pin Services Type
-CREATE TYPE service_type AS ENUM ('Pinata', 'IpfsCluster');
+CREATE TYPE service_type AS ENUM ('Pinata', 'IpfsCluster', 'IpfsCluster2');
 
 -- Upload Type
 CREATE TYPE upload_type AS ENUM (


### PR DESCRIPTION
Sister PR to https://github.com/ipfs-shipyard/nft.storage/pull/494 which can get merged and deployed now making updating to use the new cluster easier later.