### PR TITLE
feat: add PSA error handler

### DIFF
--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -43,6 +43,7 @@ import {
   DEFAULT_MODE,
   setMaintenanceModeGetter,
 } from './middleware/maintenance.js'
+import { withPsaErrorHandler } from './middleware/psa.js'
 
 const log = debug('router')
 
@@ -78,33 +79,80 @@ r.add('get', '/version', (event) => {
 })
 
 // Remote Pinning API
-r.add('get', '/api/pins', withMode(pinsList, READ_ONLY), [postCors])
-r.add('get', '/api/pins/:requestid', withMode(pinsGet, READ_ONLY), [postCors])
-r.add('post', '/api/pins', withMode(pinsAdd, READ_WRITE), [postCors])
-r.add('post', '/api/pins/:requestid', withMode(pinsReplace, READ_WRITE), [
+r.add('get', '/api/pins', withPsaErrorHandler(withMode(pinsList, READ_ONLY)), [
   postCors,
 ])
-r.add('delete', '/api/pins/:requestid', withMode(pinsDelete, READ_WRITE), [
+r.add(
+  'get',
+  '/api/pins/:requestid',
+  withPsaErrorHandler(withMode(pinsGet, READ_ONLY)),
+  [postCors]
+)
+r.add('post', '/api/pins', withPsaErrorHandler(withMode(pinsAdd, READ_WRITE)), [
   postCors,
 ])
+r.add(
+  'post',
+  '/api/pins/:requestid',
+  withPsaErrorHandler(withMode(pinsReplace, READ_WRITE)),
+  [postCors]
+)
+r.add(
+  'delete',
+  '/api/pins/:requestid',
+  withPsaErrorHandler(withMode(pinsDelete, READ_WRITE)),
+  [postCors]
+)
 
-r.add('post', '/pins', withMode(pinsAdd, READ_WRITE), [postCors])
-r.add('get', '/pins', withMode(pinsList, READ_ONLY), [postCors])
-r.add('get', '/pins/:requestid', withMode(pinsGet, READ_ONLY), [postCors])
-r.add('post', '/pins/:requestid', withMode(pinsReplace, READ_WRITE), [postCors])
-r.add('delete', '/pins/:requestid', withMode(pinsDelete, READ_WRITE), [
+r.add('post', '/pins', withPsaErrorHandler(withMode(pinsAdd, READ_WRITE)), [
   postCors,
 ])
+r.add('get', '/pins', withPsaErrorHandler(withMode(pinsList, READ_ONLY)), [
+  postCors,
+])
+r.add(
+  'get',
+  '/pins/:requestid',
+  withPsaErrorHandler(withMode(pinsGet, READ_ONLY)),
+  [postCors]
+)
+r.add(
+  'post',
+  '/pins/:requestid',
+  withPsaErrorHandler(withMode(pinsReplace, READ_WRITE)),
+  [postCors]
+)
+r.add(
+  'delete',
+  '/pins/:requestid',
+  withPsaErrorHandler(withMode(pinsDelete, READ_WRITE)),
+  [postCors]
+)
 
 // V1 routes
 r.add('post', '/v1/login', withMode(loginV1, READ_ONLY), [postCors])
 
-r.add('get', '/v1/pins', withMode(pinsListV1, READ_ONLY), [postCors])
-r.add('get', '/v1/pins/:requestid', withMode(pinsGetV1, READ_ONLY), [postCors])
-r.add('post', '/v1/pins', withMode(pinsAddV1, READ_WRITE), [postCors])
-r.add('delete', '/v1/pins/:requestid', withMode(pinsDeleteV1, READ_WRITE), [
+r.add('get', '/v1/pins', withPsaErrorHandler(withMode(pinsListV1, READ_ONLY)), [
   postCors,
 ])
+r.add(
+  'get',
+  '/v1/pins/:requestid',
+  withPsaErrorHandler(withMode(pinsGetV1, READ_ONLY)),
+  [postCors]
+)
+r.add(
+  'post',
+  '/v1/pins',
+  withPsaErrorHandler(withMode(pinsAddV1, READ_WRITE)),
+  [postCors]
+)
+r.add(
+  'delete',
+  '/v1/pins/:requestid',
+  withPsaErrorHandler(withMode(pinsDeleteV1, READ_WRITE)),
+  [postCors]
+)
 
 r.add('get', '/v1', withMode(nftListV1, READ_ONLY), [postCors])
 r.add('get', '/v1/:cid', withMode(statusV1, READ_ONLY), [postCors])

--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -38,8 +38,8 @@ import { pinsGetV1 } from './routes-v1/pins-get.js'
 import { pinsListV1 } from './routes-v1/pins-list.js'
 import {
   withMode,
-  READ_ONLY,
-  READ_WRITE,
+  READ_ONLY as RO,
+  READ_WRITE as RW,
   DEFAULT_MODE,
   setMaintenanceModeGetter,
 } from './middleware/maintenance.js'
@@ -59,14 +59,14 @@ const r = new Router({
 })
 
 // Monitoring
-r.add('get', '/metrics', withMode(metrics, READ_ONLY))
-r.add('get', '/v1/metrics', withMode(metricsV1, READ_ONLY))
+r.add('get', '/metrics', withMode(metrics, RO))
+r.add('get', '/v1/metrics', withMode(metricsV1, RO))
 
 // CORS
 r.add('options', '*', cors)
 
 // Auth
-r.add('post', '/login', withMode(login, READ_ONLY), [postCors])
+r.add('post', '/login', withMode(login, RO), [postCors])
 
 // Version
 r.add('get', '/version', (event) => {
@@ -79,122 +79,67 @@ r.add('get', '/version', (event) => {
 })
 
 // Remote Pinning API
-r.add('get', '/api/pins', withPsaErrorHandler(withMode(pinsList, READ_ONLY)), [
-  postCors,
-])
-r.add(
-  'get',
-  '/api/pins/:requestid',
-  withPsaErrorHandler(withMode(pinsGet, READ_ONLY)),
-  [postCors]
-)
-r.add('post', '/api/pins', withPsaErrorHandler(withMode(pinsAdd, READ_WRITE)), [
-  postCors,
-])
-r.add(
-  'post',
-  '/api/pins/:requestid',
-  withPsaErrorHandler(withMode(pinsReplace, READ_WRITE)),
-  [postCors]
-)
-r.add(
-  'delete',
-  '/api/pins/:requestid',
-  withPsaErrorHandler(withMode(pinsDelete, READ_WRITE)),
-  [postCors]
-)
 
-r.add('post', '/pins', withPsaErrorHandler(withMode(pinsAdd, READ_WRITE)), [
-  postCors,
-])
-r.add('get', '/pins', withPsaErrorHandler(withMode(pinsList, READ_ONLY)), [
-  postCors,
-])
-r.add(
-  'get',
-  '/pins/:requestid',
-  withPsaErrorHandler(withMode(pinsGet, READ_ONLY)),
-  [postCors]
-)
-r.add(
-  'post',
-  '/pins/:requestid',
-  withPsaErrorHandler(withMode(pinsReplace, READ_WRITE)),
-  [postCors]
-)
-r.add(
-  'delete',
-  '/pins/:requestid',
-  withPsaErrorHandler(withMode(pinsDelete, READ_WRITE)),
-  [postCors]
-)
+/**
+ * Apply Pinning Services API Middleware
+ * @param {import('./utils/router.js').Handler} handler
+ * @param {import('./middleware/maintenance').Mode} mode
+ * @returns {import('./utils/router.js').Handler}
+ */
+const psa = (handler, mode) => withPsaErrorHandler(withMode(handler, mode))
+
+// Note: /api/* endpoints are legacy and will eventually be removed.
+r.add('get', '/api/pins', psa(pinsList, RO), [postCors])
+r.add('get', '/api/pins/:requestid', psa(pinsGet, RO), [postCors])
+r.add('post', '/api/pins', psa(pinsAdd, RW), [postCors])
+r.add('post', '/api/pins/:requestid', psa(pinsReplace, RW), [postCors])
+r.add('delete', '/api/pins/:requestid', psa(pinsDelete, RW), [postCors])
+
+r.add('post', '/pins', psa(pinsAdd, RW), [postCors])
+r.add('get', '/pins', psa(pinsList, RO), [postCors])
+r.add('get', '/pins/:requestid', psa(pinsGet, RO), [postCors])
+r.add('post', '/pins/:requestid', psa(pinsReplace, RW), [postCors])
+r.add('delete', '/pins/:requestid', psa(pinsDelete, RW), [postCors])
 
 // V1 routes
-r.add('post', '/v1/login', withMode(loginV1, READ_ONLY), [postCors])
+r.add('post', '/v1/login', withMode(loginV1, RO), [postCors])
 
-r.add('get', '/v1/pins', withPsaErrorHandler(withMode(pinsListV1, READ_ONLY)), [
-  postCors,
-])
-r.add(
-  'get',
-  '/v1/pins/:requestid',
-  withPsaErrorHandler(withMode(pinsGetV1, READ_ONLY)),
-  [postCors]
-)
-r.add(
-  'post',
-  '/v1/pins',
-  withPsaErrorHandler(withMode(pinsAddV1, READ_WRITE)),
-  [postCors]
-)
-r.add(
-  'delete',
-  '/v1/pins/:requestid',
-  withPsaErrorHandler(withMode(pinsDeleteV1, READ_WRITE)),
-  [postCors]
-)
+r.add('get', '/v1/pins', psa(pinsListV1, RO), [postCors])
+r.add('get', '/v1/pins/:requestid', psa(pinsGetV1, RO), [postCors])
+r.add('post', '/v1/pins', psa(pinsAddV1, RW), [postCors])
+r.add('delete', '/v1/pins/:requestid', psa(pinsDeleteV1, RW), [postCors])
 
-r.add('get', '/v1', withMode(nftListV1, READ_ONLY), [postCors])
-r.add('get', '/v1/:cid', withMode(statusV1, READ_ONLY), [postCors])
-r.add('post', '/v1/upload', withMode(uploadV1, READ_WRITE), [postCors])
-r.add('post', '/v1/store', withMode(nftStoreV1, READ_WRITE), [postCors])
-r.add('delete', '/v1/:cid', withMode(nftDeleteV1, READ_WRITE), [postCors])
+r.add('get', '/v1', withMode(nftListV1, RO), [postCors])
+r.add('get', '/v1/:cid', withMode(statusV1, RO), [postCors])
+r.add('post', '/v1/upload', withMode(uploadV1, RW), [postCors])
+r.add('post', '/v1/store', withMode(nftStoreV1, RW), [postCors])
+r.add('delete', '/v1/:cid', withMode(nftDeleteV1, RW), [postCors])
 
-r.add('get', '/v1/check/:cid', withMode(checkV1, READ_ONLY), [postCors])
+r.add('get', '/v1/check/:cid', withMode(checkV1, RO), [postCors])
 
-r.add('get', '/v1/internal/tokens', withMode(tokensListV1, READ_ONLY), [
-  postCors,
-])
-r.add('post', '/v1/internal/tokens', withMode(tokensCreateV1, READ_WRITE), [
-  postCors,
-])
-r.add('delete', '/v1/internal/tokens', withMode(tokensDeleteV1, READ_WRITE), [
-  postCors,
-])
+r.add('get', '/v1/internal/tokens', withMode(tokensListV1, RO), [postCors])
+r.add('post', '/v1/internal/tokens', withMode(tokensCreateV1, RW), [postCors])
+r.add('delete', '/v1/internal/tokens', withMode(tokensDeleteV1, RW), [postCors])
 
 // Public API
-r.add('get', '/api', withMode(list, READ_ONLY), [postCors])
-r.add('get', '/api/check/:cid', withMode(check, READ_ONLY), [postCors])
-r.add('get', '/api/:cid', withMode(status, READ_ONLY), [postCors])
-r.add('post', '/api/upload', withMode(upload, READ_WRITE), [postCors])
-r.add('delete', '/api/:cid', withMode(remove, READ_WRITE), [postCors])
+r.add('get', '/api', withMode(list, RO), [postCors])
+r.add('get', '/api/check/:cid', withMode(check, RO), [postCors])
+r.add('get', '/api/:cid', withMode(status, RO), [postCors])
+r.add('post', '/api/upload', withMode(upload, RW), [postCors])
+r.add('delete', '/api/:cid', withMode(remove, RW), [postCors])
 
-r.add('get', '', withMode(list, READ_ONLY), [postCors])
-r.add('get', '/check/:cid', withMode(check, READ_ONLY), [postCors])
-r.add('get', '/:cid', withMode(status, READ_ONLY), [postCors])
-r.add('post', '/upload', withMode(upload, READ_WRITE), [postCors])
-r.add('post', '/store', withMode(store, READ_WRITE), [postCors])
-r.add('delete', '/:cid', withMode(remove, READ_WRITE), [postCors])
+r.add('get', '', withMode(list, RO), [postCors])
+r.add('get', '/check/:cid', withMode(check, RO), [postCors])
+r.add('get', '/:cid', withMode(status, RO), [postCors])
+r.add('post', '/upload', withMode(upload, RW), [postCors])
+r.add('post', '/store', withMode(store, RW), [postCors])
+r.add('delete', '/:cid', withMode(remove, RW), [postCors])
 
 // Private API
-r.add('get', '/internal/tokens', withMode(tokensList, READ_ONLY), [postCors])
-r.add('post', '/internal/tokens', withMode(tokensCreate, READ_WRITE), [
-  postCors,
-])
-r.add('delete', '/internal/tokens', withMode(tokensDelete, READ_WRITE), [
-  postCors,
-])
-r.add('get', '/internal/list2', withMode(getNFT, READ_ONLY), [postCors])
+r.add('get', '/internal/tokens', withMode(tokensList, RO), [postCors])
+r.add('post', '/internal/tokens', withMode(tokensCreate, RW), [postCors])
+r.add('delete', '/internal/tokens', withMode(tokensDelete, RW), [postCors])
+r.add('get', '/internal/list2', withMode(getNFT, RO), [postCors])
 
 r.add('all', '*', notFound)
 addEventListener('fetch', r.listen.bind(r))

--- a/packages/api/src/middleware/psa.js
+++ b/packages/api/src/middleware/psa.js
@@ -1,0 +1,29 @@
+import { maybeCapture } from '../errors.js'
+import { JSONResponse } from '../utils/json-response.js'
+
+/**
+ * Catch an error and respond with a response as required by the PSA spec,
+ * logging the actual error with sentry.
+ *
+ * @typedef {import('../utils/router.js').Handler} Handler
+ * @param {Handler} handler
+ * @returns {Handler}
+ */
+export function withPsaErrorHandler(handler) {
+  return async (event, ctx) => {
+    try {
+      return await handler(event, ctx)
+    } catch (err) {
+      const { status } = maybeCapture(err, { sentry: ctx.sentry })
+      return new JSONResponse(
+        {
+          error: {
+            reason: 'INTERNAL_SERVER_ERROR',
+            details: 'An unexpected error occurred.',
+          },
+        },
+        { status }
+      )
+    }
+  }
+}

--- a/packages/api/src/routes-v1/pins-add.js
+++ b/packages/api/src/routes-v1/pins-add.js
@@ -1,11 +1,8 @@
 import { JSONResponse } from '../utils/json-response.js'
 import * as cluster from '../cluster.js'
 import { validate } from '../utils/auth-v1.js'
-import { debug } from '../utils/debug.js'
 import { parseCidPinning } from '../utils/utils.js'
 import { toPinsResponse } from '../utils/db-transforms.js'
-
-const log = debug('pins-add')
 
 /** @type {import('../utils/router.js').Handler} */
 export async function pinsAddV1(event, ctx) {
@@ -15,7 +12,7 @@ export async function pinsAddV1(event, ctx) {
   const pinData = await event.request.json()
 
   // validate CID
-  let cid = parseCidPinning(pinData.cid)
+  const cid = parseCidPinning(pinData.cid)
   if (!cid) {
     return new JSONResponse(
       {

--- a/packages/api/src/routes-v1/pins-delete.js
+++ b/packages/api/src/routes-v1/pins-delete.js
@@ -7,7 +7,7 @@ export async function pinsDeleteV1(event, ctx) {
   const { params } = ctx
   const { user, db } = await validate(event, ctx)
 
-  let cid = parseCidPinning(params.requestid)
+  const cid = parseCidPinning(params.requestid)
   if (!cid) {
     return new JSONResponse(
       {

--- a/packages/api/src/routes-v1/pins-get.js
+++ b/packages/api/src/routes-v1/pins-get.js
@@ -8,7 +8,7 @@ export async function pinsGetV1(event, ctx) {
   const { params } = ctx
   const { user, db } = await validate(event, ctx)
 
-  let cid = parseCidPinning(params.requestid)
+  const cid = parseCidPinning(params.requestid)
   if (!cid) {
     return new JSONResponse(
       {

--- a/packages/api/src/routes-v1/pins-list.js
+++ b/packages/api/src/routes-v1/pins-list.js
@@ -23,44 +23,32 @@ export async function pinsListV1(event, ctx) {
     const params = result.data
 
     // Query database
-    try {
-      const data = await db.listUploads(user.id, params)
+    const data = await db.listUploads(user.id, params)
 
-      // Not found
-      if (!data || data.length === 0) {
-        return new JSONResponse(
-          {
-            error: {
-              reason: 'NOT_FOUND',
-              details: 'The specified resource was not found',
-            },
-          },
-          { status: 404 }
-        )
-      }
-
-      // Aggregate result into proper output
-      let count = 0
-      const results = []
-      for (const upload of data) {
-        if (upload.content.pin.length > 0) {
-          count++
-          results.push(toPinsResponse(upload))
-        }
-      }
-
-      return new JSONResponse({ count, results })
-    } catch (/** @type{any} */ err) {
+    // Not found
+    if (!data || data.length === 0) {
       return new JSONResponse(
         {
           error: {
-            reason: 'INTERNAL_SERVER_ERROR',
-            details: err.message,
+            reason: 'NOT_FOUND',
+            details: 'The specified resource was not found',
           },
         },
-        { status: 500 }
+        { status: 404 }
       )
     }
+
+    // Aggregate result into proper output
+    let count = 0
+    const results = []
+    for (const upload of data) {
+      if (upload.content.pin.length > 0) {
+        count++
+        results.push(toPinsResponse(upload))
+      }
+    }
+
+    return new JSONResponse({ count, results })
   }
 }
 


### PR DESCRIPTION
PSA error responses are not like nft.storage API responses. This PR adds middleware to intercept thrown errors and respond with an object in the shape expected for PSA responses.