### PR TITLE
refactor: move v1 to root (minimal changes)

### DIFF
--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -43,6 +43,7 @@ import {
   DEFAULT_MODE,
   setMaintenanceModeGetter,
 } from './middleware/maintenance.js'
+import { withPsaErrorHandler } from './middleware/psa.js'
 
 const log = debug('router')
 
@@ -78,33 +79,80 @@ r.add('get', '/version', (event) => {
 })
 
 // Remote Pinning API
-r.add('get', '/api/pins', withMode(pinsList, READ_ONLY), [postCors])
-r.add('get', '/api/pins/:requestid', withMode(pinsGet, READ_ONLY), [postCors])
-r.add('post', '/api/pins', withMode(pinsAdd, READ_WRITE), [postCors])
-r.add('post', '/api/pins/:requestid', withMode(pinsReplace, READ_WRITE), [
+r.add('get', '/api/pins', withPsaErrorHandler(withMode(pinsList, READ_ONLY)), [
   postCors,
 ])
-r.add('delete', '/api/pins/:requestid', withMode(pinsDelete, READ_WRITE), [
+r.add(
+  'get',
+  '/api/pins/:requestid',
+  withPsaErrorHandler(withMode(pinsGet, READ_ONLY)),
+  [postCors]
+)
+r.add('post', '/api/pins', withPsaErrorHandler(withMode(pinsAdd, READ_WRITE)), [
   postCors,
 ])
+r.add(
+  'post',
+  '/api/pins/:requestid',
+  withPsaErrorHandler(withMode(pinsReplace, READ_WRITE)),
+  [postCors]
+)
+r.add(
+  'delete',
+  '/api/pins/:requestid',
+  withPsaErrorHandler(withMode(pinsDelete, READ_WRITE)),
+  [postCors]
+)
 
-r.add('post', '/pins', withMode(pinsAdd, READ_WRITE), [postCors])
-r.add('get', '/pins', withMode(pinsList, READ_ONLY), [postCors])
-r.add('get', '/pins/:requestid', withMode(pinsGet, READ_ONLY), [postCors])
-r.add('post', '/pins/:requestid', withMode(pinsReplace, READ_WRITE), [postCors])
-r.add('delete', '/pins/:requestid', withMode(pinsDelete, READ_WRITE), [
+r.add('post', '/pins', withPsaErrorHandler(withMode(pinsAdd, READ_WRITE)), [
   postCors,
 ])
+r.add('get', '/pins', withPsaErrorHandler(withMode(pinsList, READ_ONLY)), [
+  postCors,
+])
+r.add(
+  'get',
+  '/pins/:requestid',
+  withPsaErrorHandler(withMode(pinsGet, READ_ONLY)),
+  [postCors]
+)
+r.add(
+  'post',
+  '/pins/:requestid',
+  withPsaErrorHandler(withMode(pinsReplace, READ_WRITE)),
+  [postCors]
+)
+r.add(
+  'delete',
+  '/pins/:requestid',
+  withPsaErrorHandler(withMode(pinsDelete, READ_WRITE)),
+  [postCors]
+)
 
 // V1 routes
 r.add('post', '/v1/login', withMode(loginV1, READ_ONLY), [postCors])
 
-r.add('get', '/v1/pins', withMode(pinsListV1, READ_ONLY), [postCors])
-r.add('get', '/v1/pins/:requestid', withMode(pinsGetV1, READ_ONLY), [postCors])
-r.add('post', '/v1/pins', withMode(pinsAddV1, READ_WRITE), [postCors])
-r.add('delete', '/v1/pins/:requestid', withMode(pinsDeleteV1, READ_WRITE), [
+r.add('get', '/v1/pins', withPsaErrorHandler(withMode(pinsListV1, READ_ONLY)), [
   postCors,
 ])
+r.add(
+  'get',
+  '/v1/pins/:requestid',
+  withPsaErrorHandler(withMode(pinsGetV1, READ_ONLY)),
+  [postCors]
+)
+r.add(
+  'post',
+  '/v1/pins',
+  withPsaErrorHandler(withMode(pinsAddV1, READ_WRITE)),
+  [postCors]
+)
+r.add(
+  'delete',
+  '/v1/pins/:requestid',
+  withPsaErrorHandler(withMode(pinsDeleteV1, READ_WRITE)),
+  [postCors]
+)
 
 r.add('get', '/v1', withMode(nftListV1, READ_ONLY), [postCors])
 r.add('get', '/v1/:cid', withMode(statusV1, READ_ONLY), [postCors])

--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -38,8 +38,8 @@ import { pinsGetV1 } from './routes-v1/pins-get.js'
 import { pinsListV1 } from './routes-v1/pins-list.js'
 import {
   withMode,
-  READ_ONLY,
-  READ_WRITE,
+  READ_ONLY as RO,
+  READ_WRITE as RW,
   DEFAULT_MODE,
   setMaintenanceModeGetter,
 } from './middleware/maintenance.js'
@@ -59,14 +59,14 @@ const r = new Router({
 })
 
 // Monitoring
-r.add('get', '/metrics', withMode(metrics, READ_ONLY))
-r.add('get', '/v1/metrics', withMode(metricsV1, READ_ONLY))
+r.add('get', '/metrics', withMode(metrics, RO))
+r.add('get', '/v1/metrics', withMode(metricsV1, RO))
 
 // CORS
 r.add('options', '*', cors)
 
 // Auth
-r.add('post', '/login', withMode(login, READ_ONLY), [postCors])
+r.add('post', '/login', withMode(login, RO), [postCors])
 
 // Version
 r.add('get', '/version', (event) => {
@@ -79,122 +79,67 @@ r.add('get', '/version', (event) => {
 })
 
 // Remote Pinning API
-r.add('get', '/api/pins', withPsaErrorHandler(withMode(pinsList, READ_ONLY)), [
-  postCors,
-])
-r.add(
-  'get',
-  '/api/pins/:requestid',
-  withPsaErrorHandler(withMode(pinsGet, READ_ONLY)),
-  [postCors]
-)
-r.add('post', '/api/pins', withPsaErrorHandler(withMode(pinsAdd, READ_WRITE)), [
-  postCors,
-])
-r.add(
-  'post',
-  '/api/pins/:requestid',
-  withPsaErrorHandler(withMode(pinsReplace, READ_WRITE)),
-  [postCors]
-)
-r.add(
-  'delete',
-  '/api/pins/:requestid',
-  withPsaErrorHandler(withMode(pinsDelete, READ_WRITE)),
-  [postCors]
-)
 
-r.add('post', '/pins', withPsaErrorHandler(withMode(pinsAdd, READ_WRITE)), [
-  postCors,
-])
-r.add('get', '/pins', withPsaErrorHandler(withMode(pinsList, READ_ONLY)), [
-  postCors,
-])
-r.add(
-  'get',
-  '/pins/:requestid',
-  withPsaErrorHandler(withMode(pinsGet, READ_ONLY)),
-  [postCors]
-)
-r.add(
-  'post',
-  '/pins/:requestid',
-  withPsaErrorHandler(withMode(pinsReplace, READ_WRITE)),
-  [postCors]
-)
-r.add(
-  'delete',
-  '/pins/:requestid',
-  withPsaErrorHandler(withMode(pinsDelete, READ_WRITE)),
-  [postCors]
-)
+/**
+ * Apply Pinning Services API Middleware
+ * @param {import('./utils/router.js').Handler} handler
+ * @param {import('./middleware/maintenance').Mode} mode
+ * @returns {import('./utils/router.js').Handler}
+ */
+const psa = (handler, mode) => withPsaErrorHandler(withMode(handler, mode))
+
+// Note: /api/* endpoints are legacy and will eventually be removed.
+r.add('get', '/api/pins', psa(pinsList, RO), [postCors])
+r.add('get', '/api/pins/:requestid', psa(pinsGet, RO), [postCors])
+r.add('post', '/api/pins', psa(pinsAdd, RW), [postCors])
+r.add('post', '/api/pins/:requestid', psa(pinsReplace, RW), [postCors])
+r.add('delete', '/api/pins/:requestid', psa(pinsDelete, RW), [postCors])
+
+r.add('post', '/pins', psa(pinsAdd, RW), [postCors])
+r.add('get', '/pins', psa(pinsList, RO), [postCors])
+r.add('get', '/pins/:requestid', psa(pinsGet, RO), [postCors])
+r.add('post', '/pins/:requestid', psa(pinsReplace, RW), [postCors])
+r.add('delete', '/pins/:requestid', psa(pinsDelete, RW), [postCors])
 
 // V1 routes
-r.add('post', '/v1/login', withMode(loginV1, READ_ONLY), [postCors])
+r.add('post', '/v1/login', withMode(loginV1, RO), [postCors])
 
-r.add('get', '/v1/pins', withPsaErrorHandler(withMode(pinsListV1, READ_ONLY)), [
-  postCors,
-])
-r.add(
-  'get',
-  '/v1/pins/:requestid',
-  withPsaErrorHandler(withMode(pinsGetV1, READ_ONLY)),
-  [postCors]
-)
-r.add(
-  'post',
-  '/v1/pins',
-  withPsaErrorHandler(withMode(pinsAddV1, READ_WRITE)),
-  [postCors]
-)
-r.add(
-  'delete',
-  '/v1/pins/:requestid',
-  withPsaErrorHandler(withMode(pinsDeleteV1, READ_WRITE)),
-  [postCors]
-)
+r.add('get', '/v1/pins', psa(pinsListV1, RO), [postCors])
+r.add('get', '/v1/pins/:requestid', psa(pinsGetV1, RO), [postCors])
+r.add('post', '/v1/pins', psa(pinsAddV1, RW), [postCors])
+r.add('delete', '/v1/pins/:requestid', psa(pinsDeleteV1, RW), [postCors])
 
-r.add('get', '/v1', withMode(nftListV1, READ_ONLY), [postCors])
-r.add('get', '/v1/:cid', withMode(statusV1, READ_ONLY), [postCors])
-r.add('post', '/v1/upload', withMode(uploadV1, READ_WRITE), [postCors])
-r.add('post', '/v1/store', withMode(nftStoreV1, READ_WRITE), [postCors])
-r.add('delete', '/v1/:cid', withMode(nftDeleteV1, READ_WRITE), [postCors])
+r.add('get', '/v1', withMode(nftListV1, RO), [postCors])
+r.add('get', '/v1/:cid', withMode(statusV1, RO), [postCors])
+r.add('post', '/v1/upload', withMode(uploadV1, RW), [postCors])
+r.add('post', '/v1/store', withMode(nftStoreV1, RW), [postCors])
+r.add('delete', '/v1/:cid', withMode(nftDeleteV1, RW), [postCors])
 
-r.add('get', '/v1/check/:cid', withMode(checkV1, READ_ONLY), [postCors])
+r.add('get', '/v1/check/:cid', withMode(checkV1, RO), [postCors])
 
-r.add('get', '/v1/internal/tokens', withMode(tokensListV1, READ_ONLY), [
-  postCors,
-])
-r.add('post', '/v1/internal/tokens', withMode(tokensCreateV1, READ_WRITE), [
-  postCors,
-])
-r.add('delete', '/v1/internal/tokens', withMode(tokensDeleteV1, READ_WRITE), [
-  postCors,
-])
+r.add('get', '/v1/internal/tokens', withMode(tokensListV1, RO), [postCors])
+r.add('post', '/v1/internal/tokens', withMode(tokensCreateV1, RW), [postCors])
+r.add('delete', '/v1/internal/tokens', withMode(tokensDeleteV1, RW), [postCors])
 
 // Public API
-r.add('get', '/api', withMode(list, READ_ONLY), [postCors])
-r.add('get', '/api/check/:cid', withMode(check, READ_ONLY), [postCors])
-r.add('get', '/api/:cid', withMode(status, READ_ONLY), [postCors])
-r.add('post', '/api/upload', withMode(upload, READ_WRITE), [postCors])
-r.add('delete', '/api/:cid', withMode(remove, READ_WRITE), [postCors])
+r.add('get', '/api', withMode(list, RO), [postCors])
+r.add('get', '/api/check/:cid', withMode(check, RO), [postCors])
+r.add('get', '/api/:cid', withMode(status, RO), [postCors])
+r.add('post', '/api/upload', withMode(upload, RW), [postCors])
+r.add('delete', '/api/:cid', withMode(remove, RW), [postCors])
 
-r.add('get', '', withMode(list, READ_ONLY), [postCors])
-r.add('get', '/check/:cid', withMode(check, READ_ONLY), [postCors])
-r.add('get', '/:cid', withMode(status, READ_ONLY), [postCors])
-r.add('post', '/upload', withMode(upload, READ_WRITE), [postCors])
-r.add('post', '/store', withMode(store, READ_WRITE), [postCors])
-r.add('delete', '/:cid', withMode(remove, READ_WRITE), [postCors])
+r.add('get', '', withMode(list, RO), [postCors])
+r.add('get', '/check/:cid', withMode(check, RO), [postCors])
+r.add('get', '/:cid', withMode(status, RO), [postCors])
+r.add('post', '/upload', withMode(upload, RW), [postCors])
+r.add('post', '/store', withMode(store, RW), [postCors])
+r.add('delete', '/:cid', withMode(remove, RW), [postCors])
 
 // Private API
-r.add('get', '/internal/tokens', withMode(tokensList, READ_ONLY), [postCors])
-r.add('post', '/internal/tokens', withMode(tokensCreate, READ_WRITE), [
-  postCors,
-])
-r.add('delete', '/internal/tokens', withMode(tokensDelete, READ_WRITE), [
-  postCors,
-])
-r.add('get', '/internal/list2', withMode(getNFT, READ_ONLY), [postCors])
+r.add('get', '/internal/tokens', withMode(tokensList, RO), [postCors])
+r.add('post', '/internal/tokens', withMode(tokensCreate, RW), [postCors])
+r.add('delete', '/internal/tokens', withMode(tokensDelete, RW), [postCors])
+r.add('get', '/internal/list2', withMode(getNFT, RO), [postCors])
 
 r.add('all', '*', notFound)
 addEventListener('fetch', r.listen.bind(r))

--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -36,6 +36,7 @@ import { pinsAddV1 } from './routes-v1/pins-add.js'
 import { pinsDeleteV1 } from './routes-v1/pins-delete.js'
 import { pinsGetV1 } from './routes-v1/pins-get.js'
 import { pinsListV1 } from './routes-v1/pins-list.js'
+import { pinsReplace as pinsReplaceV1 } from './routes-v1/pins-replace.js'
 import {
   withMode,
   READ_ONLY as RO,
@@ -59,14 +60,14 @@ const r = new Router({
 })
 
 // Monitoring
-r.add('get', '/metrics', withMode(metrics, RO))
-r.add('get', '/v1/metrics', withMode(metricsV1, RO))
+r.add('get', '/v0/metrics', withMode(metrics, RO))
+r.add('get', '/metrics', withMode(metricsV1, RO))
 
 // CORS
 r.add('options', '*', cors)
 
 // Auth
-r.add('post', '/login', withMode(login, RO), [postCors])
+r.add('post', '/v0/login', withMode(login, RO), [postCors])
 
 // Version
 r.add('get', '/version', (event) => {
@@ -89,57 +90,58 @@ r.add('get', '/version', (event) => {
 const psa = (handler, mode) => withPsaErrorHandler(withMode(handler, mode))
 
 // Note: /api/* endpoints are legacy and will eventually be removed.
-r.add('get', '/api/pins', psa(pinsList, RO), [postCors])
-r.add('get', '/api/pins/:requestid', psa(pinsGet, RO), [postCors])
-r.add('post', '/api/pins', psa(pinsAdd, RW), [postCors])
-r.add('post', '/api/pins/:requestid', psa(pinsReplace, RW), [postCors])
-r.add('delete', '/api/pins/:requestid', psa(pinsDelete, RW), [postCors])
+r.add('get', '/api/pins', psa(pinsListV1, RO), [postCors])
+r.add('get', '/api/pins/:requestid', psa(pinsGetV1, RO), [postCors])
+r.add('post', '/api/pins', psa(pinsAddV1, RW), [postCors])
+r.add('post', '/api/pins/:requestid', psa(pinsReplaceV1, RW), [postCors])
+r.add('delete', '/api/pins/:requestid', psa(pinsDeleteV1, RW), [postCors])
 
-r.add('post', '/pins', psa(pinsAdd, RW), [postCors])
-r.add('get', '/pins', psa(pinsList, RO), [postCors])
-r.add('get', '/pins/:requestid', psa(pinsGet, RO), [postCors])
-r.add('post', '/pins/:requestid', psa(pinsReplace, RW), [postCors])
-r.add('delete', '/pins/:requestid', psa(pinsDelete, RW), [postCors])
+r.add('post', '/v0/pins', psa(pinsAdd, RW), [postCors])
+r.add('get', '/v0/pins', psa(pinsList, RO), [postCors])
+r.add('get', '/v0/pins/:requestid', psa(pinsGet, RO), [postCors])
+r.add('post', '/v0/pins/:requestid', psa(pinsReplace, RW), [postCors])
+r.add('delete', '/v0/pins/:requestid', psa(pinsDelete, RW), [postCors])
 
 // V1 routes
-r.add('post', '/v1/login', withMode(loginV1, RO), [postCors])
+r.add('post', '/login', withMode(loginV1, RO), [postCors])
 
-r.add('get', '/v1/pins', psa(pinsListV1, RO), [postCors])
-r.add('get', '/v1/pins/:requestid', psa(pinsGetV1, RO), [postCors])
-r.add('post', '/v1/pins', psa(pinsAddV1, RW), [postCors])
-r.add('delete', '/v1/pins/:requestid', psa(pinsDeleteV1, RW), [postCors])
+r.add('get', '/pins', psa(pinsListV1, RO), [postCors])
+r.add('get', '/pins/:requestid', psa(pinsGetV1, RO), [postCors])
+r.add('post', '/pins', psa(pinsAddV1, RW), [postCors])
+r.add('post', '/pins/:requestid', psa(pinsReplaceV1, RW), [postCors])
+r.add('delete', '/pins/:requestid', psa(pinsDeleteV1, RW), [postCors])
 
-r.add('get', '/v1', withMode(nftListV1, RO), [postCors])
-r.add('get', '/v1/:cid', withMode(statusV1, RO), [postCors])
-r.add('post', '/v1/upload', withMode(uploadV1, RW), [postCors])
-r.add('post', '/v1/store', withMode(nftStoreV1, RW), [postCors])
-r.add('delete', '/v1/:cid', withMode(nftDeleteV1, RW), [postCors])
+r.add('get', '', withMode(nftListV1, RO), [postCors])
+r.add('get', '/:cid', withMode(statusV1, RO), [postCors])
+r.add('post', '/upload', withMode(uploadV1, RW), [postCors])
+r.add('post', '/store', withMode(nftStoreV1, RW), [postCors])
+r.add('delete', '/:cid', withMode(nftDeleteV1, RW), [postCors])
 
-r.add('get', '/v1/check/:cid', withMode(checkV1, RO), [postCors])
+r.add('get', '/check/:cid', withMode(checkV1, RO), [postCors])
 
-r.add('get', '/v1/internal/tokens', withMode(tokensListV1, RO), [postCors])
-r.add('post', '/v1/internal/tokens', withMode(tokensCreateV1, RW), [postCors])
-r.add('delete', '/v1/internal/tokens', withMode(tokensDeleteV1, RW), [postCors])
+r.add('get', '/internal/tokens', withMode(tokensListV1, RO), [postCors])
+r.add('post', '/internal/tokens', withMode(tokensCreateV1, RW), [postCors])
+r.add('delete', '/internal/tokens', withMode(tokensDeleteV1, RW), [postCors])
 
 // Public API
-r.add('get', '/api', withMode(list, RO), [postCors])
-r.add('get', '/api/check/:cid', withMode(check, RO), [postCors])
-r.add('get', '/api/:cid', withMode(status, RO), [postCors])
-r.add('post', '/api/upload', withMode(upload, RW), [postCors])
-r.add('delete', '/api/:cid', withMode(remove, RW), [postCors])
+r.add('get', '/api', withMode(nftListV1, RO), [postCors])
+r.add('get', '/api/check/:cid', withMode(checkV1, RO), [postCors])
+r.add('get', '/api/:cid', withMode(statusV1, RO), [postCors])
+r.add('post', '/api/upload', withMode(uploadV1, RW), [postCors])
+r.add('delete', '/api/:cid', withMode(nftDeleteV1, RW), [postCors])
 
-r.add('get', '', withMode(list, RO), [postCors])
-r.add('get', '/check/:cid', withMode(check, RO), [postCors])
-r.add('get', '/:cid', withMode(status, RO), [postCors])
-r.add('post', '/upload', withMode(upload, RW), [postCors])
-r.add('post', '/store', withMode(store, RW), [postCors])
-r.add('delete', '/:cid', withMode(remove, RW), [postCors])
+r.add('get', '/v0', withMode(list, RO), [postCors])
+r.add('get', '/v0/check/:cid', withMode(check, RO), [postCors])
+r.add('get', '/v0/:cid', withMode(status, RO), [postCors])
+r.add('post', '/v0/upload', withMode(upload, RW), [postCors])
+r.add('post', '/v0/store', withMode(store, RW), [postCors])
+r.add('delete', '/v0/:cid', withMode(remove, RW), [postCors])
 
 // Private API
-r.add('get', '/internal/tokens', withMode(tokensList, RO), [postCors])
-r.add('post', '/internal/tokens', withMode(tokensCreate, RW), [postCors])
-r.add('delete', '/internal/tokens', withMode(tokensDelete, RW), [postCors])
-r.add('get', '/internal/list2', withMode(getNFT, RO), [postCors])
+r.add('get', '/v0/internal/tokens', withMode(tokensList, RO), [postCors])
+r.add('post', '/v0/internal/tokens', withMode(tokensCreate, RW), [postCors])
+r.add('delete', '/v0/internal/tokens', withMode(tokensDelete, RW), [postCors])
+r.add('get', '/v0/internal/list2', withMode(getNFT, RO), [postCors])
 
 r.add('all', '*', notFound)
 addEventListener('fetch', r.listen.bind(r))

--- a/packages/api/src/middleware/psa.js
+++ b/packages/api/src/middleware/psa.js
@@ -1,0 +1,29 @@
+import { maybeCapture } from '../errors.js'
+import { JSONResponse } from '../utils/json-response.js'
+
+/**
+ * Catch an error and respond with a response as required by the PSA spec,
+ * logging the actual error with sentry.
+ *
+ * @typedef {import('../utils/router.js').Handler} Handler
+ * @param {Handler} handler
+ * @returns {Handler}
+ */
+export function withPsaErrorHandler(handler) {
+  return async (event, ctx) => {
+    try {
+      return await handler(event, ctx)
+    } catch (err) {
+      const { status } = maybeCapture(err, { sentry: ctx.sentry })
+      return new JSONResponse(
+        {
+          error: {
+            reason: 'INTERNAL_SERVER_ERROR',
+            details: 'An unexpected error occurred.',
+          },
+        },
+        { status }
+      )
+    }
+  }
+}

--- a/packages/api/src/routes-v1/pins-add.js
+++ b/packages/api/src/routes-v1/pins-add.js
@@ -1,11 +1,8 @@
 import { JSONResponse } from '../utils/json-response.js'
 import * as cluster from '../cluster.js'
 import { validate } from '../utils/auth-v1.js'
-import { debug } from '../utils/debug.js'
 import { parseCidPinning } from '../utils/utils.js'
 import { toPinsResponse } from '../utils/db-transforms.js'
-
-const log = debug('pins-add')
 
 /** @type {import('../utils/router.js').Handler} */
 export async function pinsAddV1(event, ctx) {
@@ -15,7 +12,7 @@ export async function pinsAddV1(event, ctx) {
   const pinData = await event.request.json()
 
   // validate CID
-  let cid = parseCidPinning(pinData.cid)
+  const cid = parseCidPinning(pinData.cid)
   if (!cid) {
     return new JSONResponse(
       {

--- a/packages/api/src/routes-v1/pins-delete.js
+++ b/packages/api/src/routes-v1/pins-delete.js
@@ -7,7 +7,7 @@ export async function pinsDeleteV1(event, ctx) {
   const { params } = ctx
   const { user, db } = await validate(event, ctx)
 
-  let cid = parseCidPinning(params.requestid)
+  const cid = parseCidPinning(params.requestid)
   if (!cid) {
     return new JSONResponse(
       {

--- a/packages/api/src/routes-v1/pins-get.js
+++ b/packages/api/src/routes-v1/pins-get.js
@@ -8,7 +8,7 @@ export async function pinsGetV1(event, ctx) {
   const { params } = ctx
   const { user, db } = await validate(event, ctx)
 
-  let cid = parseCidPinning(params.requestid)
+  const cid = parseCidPinning(params.requestid)
   if (!cid) {
     return new JSONResponse(
       {

--- a/packages/api/src/routes-v1/pins-list.js
+++ b/packages/api/src/routes-v1/pins-list.js
@@ -23,44 +23,32 @@ export async function pinsListV1(event, ctx) {
     const params = result.data
 
     // Query database
-    try {
-      const data = await db.listUploads(user.id, params)
+    const data = await db.listUploads(user.id, params)
 
-      // Not found
-      if (!data || data.length === 0) {
-        return new JSONResponse(
-          {
-            error: {
-              reason: 'NOT_FOUND',
-              details: 'The specified resource was not found',
-            },
-          },
-          { status: 404 }
-        )
-      }
-
-      // Aggregate result into proper output
-      let count = 0
-      const results = []
-      for (const upload of data) {
-        if (upload.content.pin.length > 0) {
-          count++
-          results.push(toPinsResponse(upload))
-        }
-      }
-
-      return new JSONResponse({ count, results })
-    } catch (/** @type{any} */ err) {
+    // Not found
+    if (!data || data.length === 0) {
       return new JSONResponse(
         {
           error: {
-            reason: 'INTERNAL_SERVER_ERROR',
-            details: err.message,
+            reason: 'NOT_FOUND',
+            details: 'The specified resource was not found',
           },
         },
-        { status: 500 }
+        { status: 404 }
       )
     }
+
+    // Aggregate result into proper output
+    let count = 0
+    const results = []
+    for (const upload of data) {
+      if (upload.content.pin.length > 0) {
+        count++
+        results.push(toPinsResponse(upload))
+      }
+    }
+
+    return new JSONResponse({ count, results })
   }
 }
 

--- a/packages/api/src/routes-v1/pins-replace.js
+++ b/packages/api/src/routes-v1/pins-replace.js
@@ -1,0 +1,96 @@
+import { JSONResponse } from '../utils/json-response.js'
+import * as cluster from '../cluster.js'
+import { validate } from '../utils/auth-v1.js'
+import { parseCidPinning } from '../utils/utils.js'
+import { toPinsResponse } from '../utils/db-transforms.js'
+
+/** @type {import('../utils/router.js').Handler} */
+export async function pinsReplace(event, ctx) {
+  const { db, user, key } = await validate(event, ctx)
+
+  const existingCid = ctx.params.requestid
+  const existingUpload = await db.getUpload(existingCid, user.id)
+
+  if (!existingUpload) {
+    return new JSONResponse(
+      { error: { reason: 'NOT_FOUND', details: 'pin not found' } },
+      { status: 404 }
+    )
+  }
+
+  /** @type {import('../bindings').PinsAddInput} */
+  const pinData = await event.request.json()
+
+  // validate CID
+  const cid = parseCidPinning(pinData.cid)
+  if (!cid) {
+    return new JSONResponse(
+      {
+        error: {
+          reason: 'INVALID_PIN_DATA',
+          details: `Invalid request id: ${pinData.cid}`,
+        },
+      },
+      { status: 400 }
+    )
+  }
+
+  if (pinData.cid === existingCid) {
+    return new JSONResponse(
+      {
+        error: {
+          reason: 'INVALID_PIN_DATA',
+          details: 'exiting and replacement CID are the same',
+        },
+      },
+      { status: 400 }
+    )
+  }
+
+  // validate name
+  if (pinData.name && typeof pinData.name !== 'string') {
+    return new JSONResponse(
+      { error: { reason: 'INVALID_PIN_DATA', details: 'invalid name' } },
+      { status: 400 }
+    )
+  }
+  let meta
+
+  // validate meta
+  if (pinData.meta) {
+    if (typeof pinData.meta !== 'object' || Array.isArray(pinData.meta)) {
+      return new JSONResponse(
+        { error: { reason: 'INVALID_PIN_DATA', details: 'invalid metadata' } },
+        { status: 400 }
+      )
+    }
+    meta = Object.fromEntries(
+      Object.entries(pinData.meta).filter(([, v]) => typeof v === 'string')
+    )
+  }
+
+  await cluster.pin(cid.contentCid, {
+    origins: pinData.origins,
+    name: pinData.name,
+    metadata: pinData.meta,
+  })
+
+  const upload = await db.createUpload({
+    type: 'Remote',
+    content_cid: cid.contentCid,
+    source_cid: cid.sourceCid,
+    user_id: user.id,
+    key_id: key?.id,
+    origins: pinData.origins,
+    meta: pinData.meta,
+    name: pinData.name,
+  })
+
+  if (upload.content.pin[0].status === 'PinError') {
+    await cluster.recover(upload.content_cid)
+  }
+
+  await db.deleteUpload(existingCid, user.id)
+
+  return new JSONResponse(toPinsResponse(upload))
+}

--- a/packages/api/test/nfts-check-v1.spec.js
+++ b/packages/api/test/nfts-check-v1.spec.js
@@ -11,7 +11,7 @@ describe('V1 - Check NFT', () => {
       name: 'test-file11',
     })
 
-    const res = await fetch(`v1/check/${cid}`)
+    const res = await fetch(`check/${cid}`)
     const { ok, value } = await res.json()
 
     assert.equal(value.cid, cid)
@@ -27,7 +27,7 @@ describe('V1 - Check NFT', () => {
       name: 'test-file-cid-v0',
     })
 
-    const res = await fetch(`v1/check/${cid}`)
+    const res = await fetch(`check/${cid}`)
     const { ok, value } = await res.json()
     assert.equal(value.cid, cid)
     assert.equal(value.pin.status, 'queued')
@@ -36,7 +36,7 @@ describe('V1 - Check NFT', () => {
 
   it('should error on invalid cid', async () => {
     const cid = 'asdhjkahsdja'
-    const res = await fetch(`v1/check/${cid}`)
+    const res = await fetch(`check/${cid}`)
     const { ok, value, error } = await res.json()
 
     assert.equal(ok, false)
@@ -48,7 +48,7 @@ describe('V1 - Check NFT', () => {
 
   it('should error on not found', async () => {
     const cid = 'bafybeia22kh3smc7p67oa76pcleaxp4u5zatsvcndi3xrqod5vtxq5avpa'
-    const res = await fetch(`v1/check/${cid}`)
+    const res = await fetch(`check/${cid}`)
     const { ok, value, error } = await res.json()
 
     assert.equal(ok, false)

--- a/packages/api/test/nfts-check.spec.js
+++ b/packages/api/test/nfts-check.spec.js
@@ -31,7 +31,7 @@ describe('/check/{cid}', () => {
     ]
     await stores.deals.put(cid, JSON.stringify(deals))
 
-    const res = await fetch(`check/${cid}`)
+    const res = await fetch(`v0/check/${cid}`)
     assert(res)
     assert(res.ok)
     const { ok, value } = await res.json()
@@ -41,7 +41,7 @@ describe('/check/{cid}', () => {
   })
 
   it('should error if CID is not found', async () => {
-    const res = await fetch(`check/${cid}`)
+    const res = await fetch(`v0/check/${cid}`)
     assert(res)
     assert.strictEqual(res.status, 404)
     const { ok, error } = await res.json()

--- a/packages/api/test/nfts-get-v1.spec.js
+++ b/packages/api/test/nfts-get-v1.spec.js
@@ -17,7 +17,7 @@ describe('V1 - Get NFT', () => {
       name: 'test-file11',
     })
 
-    const res = await fetch(`v1/${cid}`, {
+    const res = await fetch(cid, {
       headers: { Authorization: `Bearer ${client.token}` },
     })
     const { ok, value } = await res.json()
@@ -34,7 +34,7 @@ describe('V1 - Get NFT', () => {
       name: 'test-file-cid-v0',
     })
 
-    const res = await fetch(`v1/${cid}`, {
+    const res = await fetch(cid, {
       headers: { Authorization: `Bearer ${client.token}` },
     })
     const { ok, value } = await res.json()
@@ -45,7 +45,7 @@ describe('V1 - Get NFT', () => {
 
   it('should error on invalid cid', async () => {
     const cid = 'asdhjkahsdja'
-    const res = await fetch(`v1/${cid}`, {
+    const res = await fetch(cid, {
       headers: { Authorization: `Bearer ${client.token}` },
     })
     const { ok, value, error } = await res.json()
@@ -59,7 +59,7 @@ describe('V1 - Get NFT', () => {
 
   it('should error on not found', async () => {
     const cid = 'bafybeia22kh3smc7p67oa76pcleaxp4u5zatsvcndi3xrqod5vtxq5avpa'
-    const res = await fetch(`v1/${cid}`, {
+    const res = await fetch(cid, {
       headers: { Authorization: `Bearer ${client.token}` },
     })
     const { ok, value, error } = await res.json()

--- a/packages/api/test/nfts-list-v1.spec.js
+++ b/packages/api/test/nfts-list-v1.spec.js
@@ -19,7 +19,7 @@ describe('V1 - List NFTs', () => {
     })
 
     await delay(300)
-    const res = await fetch(`v1`, {
+    const res = await fetch('', {
       headers: { Authorization: `Bearer ${client.token}` },
     })
     const { ok, value } = await res.json()
@@ -48,7 +48,7 @@ describe('V1 - List NFTs', () => {
     })
 
     await delay(300)
-    const res = await fetch(`v1?limit=1`, {
+    const res = await fetch('?limit=1', {
       headers: { Authorization: `Bearer ${client.token}` },
     })
     const { ok, value } = await res.json()
@@ -72,7 +72,7 @@ describe('V1 - List NFTs', () => {
     })
 
     await delay(300)
-    const res = await fetch(`v1?before=${date}`, {
+    const res = await fetch(`?before=${date}`, {
       headers: { Authorization: `Bearer ${client.token}` },
     })
     const { ok, value } = await res.json()
@@ -93,7 +93,7 @@ describe('V1 - List NFTs', () => {
     }
 
     await delay(300)
-    const res = await fetch(`v1`, {
+    const res = await fetch('', {
       headers: { Authorization: `Bearer ${client.token}` },
     })
     const { ok, value } = await res.json()
@@ -117,7 +117,7 @@ describe('V1 - List NFTs', () => {
     const invalidLimits = [-1, 0, 1001, 'not-a-number', 1.138]
 
     for (const limit of invalidLimits) {
-      const res = await fetch(`v1?limit=${limit}`, {
+      const res = await fetch(`?limit=${limit}`, {
         headers: { Authorization: `Bearer ${client.token}` },
       })
       assert.strictEqual(res.status, 400)

--- a/packages/api/test/nfts-store-v1.spec.js
+++ b/packages/api/test/nfts-store-v1.spec.js
@@ -24,7 +24,7 @@ describe('V1 - /store', () => {
     }
     const body = Token.encode(metadata)
 
-    const res = await fetch('/v1/store', {
+    const res = await fetch('store', {
       method: 'POST',
       headers: { Authorization: `Bearer ${token}` },
       body,

--- a/packages/api/test/nfts-store.spec.js
+++ b/packages/api/test/nfts-store.spec.js
@@ -62,7 +62,7 @@ describe('/store', () => {
     }
     const body = Token.encode(metadata)
 
-    const res = await fetch('/store', {
+    const res = await fetch('v0/store', {
       method: 'POST',
       headers: { Authorization: `Bearer ${token}` },
       body,

--- a/packages/api/test/nfts-upload.spec.js
+++ b/packages/api/test/nfts-upload.spec.js
@@ -47,7 +47,7 @@ describe('/upload', () => {
     const file = new Blob(['hello world!'])
     // expected CID for the above data
     const cid = 'bafkreidvbhs33ighmljlvr7zbv2ywwzcmp5adtf4kqvlly67cy56bdtmve'
-    const res = await fetch('/upload', {
+    const res = await fetch('v0/upload', {
       method: 'POST',
       headers: { Authorization: `Bearer ${token}` },
       body: file,
@@ -79,7 +79,7 @@ describe('/upload', () => {
     const file2 = new Blob(['hello world! 2'])
     body.append('file', file1, 'name1')
     body.append('file', file2, 'name2')
-    const res = await fetch('/upload', {
+    const res = await fetch('v0/upload', {
       method: 'POST',
       headers: { Authorization: `Bearer ${token}` },
       body,
@@ -108,7 +108,7 @@ describe('/upload', () => {
     const file2 = new Blob(['hello world! 2'])
     body.append('file', file1)
     body.append('file', file2)
-    const res = await fetch('/upload', {
+    const res = await fetch('v0/upload', {
       method: 'POST',
       headers: { Authorization: `Bearer ${token}` },
       body,
@@ -137,7 +137,7 @@ describe('/upload', () => {
     const file2 = new Blob(['hello world! 2'])
     body.append('file', new File([file1], 'name1.png'))
     body.append('file', new File([file2], 'name1.png'))
-    const res = await fetch('/upload', {
+    const res = await fetch('v0/upload', {
       method: 'POST',
       headers: { Authorization: `Bearer ${token}` },
       body,
@@ -165,7 +165,7 @@ describe('/upload', () => {
     // expected CID for the above data
     const cid = 'bafkreidvbhs33ighmljlvr7zbv2ywwzcmp5adtf4kqvlly67cy56bdtmve'
     assert.strictEqual(root.toString(), cid, 'car file has correct root')
-    const res = await fetch('/upload', {
+    const res = await fetch('v0/upload', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`,

--- a/packages/api/test/scripts/helpers.js
+++ b/packages/api/test/scripts/helpers.js
@@ -77,7 +77,7 @@ export class DBTestClient {
    * @param {{ cid: string; name: string; }} data
    */
   async addPin(data) {
-    await fetch('/v1/pins', {
+    await fetch('pins', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${this.token}`,

--- a/packages/website/lib/api.js
+++ b/packages/website/lib/api.js
@@ -22,7 +22,7 @@ export async function getToken() {
  * @param {string} version
  */
 export async function getTokens(version) {
-  const route = version === '1' ? '/v1/internal/tokens' : '/internal/tokens'
+  const route = `${version ? `/v${version}` : ''}/internal/tokens`
   const res = await fetch(API + route, {
     method: 'GET',
     headers: {
@@ -47,8 +47,8 @@ export async function getTokens(version) {
  * @param {string | undefined} [version]
  */
 export async function deleteToken(name, version) {
-  const route = version === '1' ? '/v1/internal/tokens' : '/internal/tokens'
-  const data = version === '1' ? { id: name } : { name }
+  const route = `${version ? `/v${version}` : ''}/internal/tokens`
+  const data = version !== '0' ? { id: name } : { name }
   const res = await fetch(API + route, {
     method: 'DELETE',
     headers: {
@@ -74,7 +74,7 @@ export async function deleteToken(name, version) {
  * @param {string | undefined} [version]
  */
 export async function createToken(name, version) {
-  const route = version === '1' ? '/v1/internal/tokens' : '/internal/tokens'
+  const route = `${version ? `/v${version}` : ''}/internal/tokens`
   const res = await fetch(API + route, {
     method: 'POST',
     headers: {
@@ -101,7 +101,7 @@ export async function createToken(name, version) {
  * @returns
  */
 export async function getNfts({ limit, before }, version = '') {
-  const route = version === '1' ? '/v1' : '/'
+  const route = version ? `/v${version}` : '/'
   const params = new URLSearchParams({ before, limit: String(limit) })
   const res = await fetch(`${API}${route}?${params}`, {
     method: 'GET',

--- a/packages/website/lib/magic.js
+++ b/packages/website/lib/magic.js
@@ -24,7 +24,7 @@ export function getMagic() {
  * @param {string} [version]
  */
 export async function login(token, type = 'magic', data = {}, version = '') {
-  const loginURL = version === '1' ? '/v1/login' : '/login'
+  const loginURL = version ? `/v${version}/login` : '/login'
   const res = await fetch(API + loginURL, {
     method: 'POST',
     headers: {
@@ -64,7 +64,7 @@ export async function isLoggedIn() {
  * @param {string} version
  */
 export async function loginEmail(email, version) {
-  const callback = version === '1' ? '/callback-v1' : '/callback'
+  const callback = version === '0' ? '/callback-v0' : '/callback'
   const didToken = await getMagic().auth.loginWithMagicLink({
     email: email,
     redirectURI: new URL(callback, window.location.origin).href,
@@ -85,7 +85,7 @@ export async function loginEmail(email, version) {
  * @param {string} version
  */
 export async function loginSocial(provider, version) {
-  const callback = version === '1' ? '/callback-v1' : '/callback'
+  const callback = version === '0' ? '/callback-v0' : '/callback'
 
   // @ts-ignore - TODO fix Magic extension types
   await getMagic().oauth.loginWithRedirect({

--- a/packages/website/pages/callback-v0.js
+++ b/packages/website/pages/callback-v0.js
@@ -24,24 +24,24 @@ const Callback = () => {
   useEffect(() => {
     const finishSocialLogin = async () => {
       try {
-        await redirectSocial('1')
+        await redirectSocial('0')
         await queryClient.invalidateQueries('magic-user')
-        router.push({ pathname: '/files', query: { version: '1' } })
+        router.push({ pathname: '/files', query: { version: '0' } })
       } catch (err) {
         console.error(err)
         await queryClient.invalidateQueries('magic-user')
-        router.push({ pathname: '/', query: { version: '1' } })
+        router.push({ pathname: '/', query: { version: '0' } })
       }
     }
     const finishEmailRedirectLogin = async () => {
       try {
-        await redirectMagic('1')
+        await redirectMagic('0')
         await queryClient.invalidateQueries('magic-user')
-        router.push({ pathname: '/files', query: { version: '1' } })
+        router.push({ pathname: '/files', query: { version: '0' } })
       } catch (err) {
         console.error(err)
         await queryClient.invalidateQueries('magic-user')
-        router.push({ pathname: '/', query: { version: '1' } })
+        router.push({ pathname: '/', query: { version: '0' } })
       }
     }
     if (!router.query.provider && router.query.magic_credential) {

--- a/packages/website/pages/files.js
+++ b/packages/website/pages/files.js
@@ -65,7 +65,7 @@ export default function Files({ user }) {
       try {
         const client = new NFTStorage({
           token: await getToken(),
-          endpoint: new URL(API + (version === '1' ? '/v1/' : '/')),
+          endpoint: new URL(API + (version ? `/v${version}/` : '/')),
         })
         await client.delete(cid)
       } finally {
@@ -100,7 +100,7 @@ export default function Files({ user }) {
               <Button
                 href={{
                   pathname: '/new-file',
-                  query: version ? { version: '1' } : null,
+                  query: version ? { version } : null,
                 }}
                 className="flex-none"
                 id="upload"

--- a/packages/website/pages/manage.js
+++ b/packages/website/pages/manage.js
@@ -76,12 +76,12 @@ export default function ManageKeys({ user }) {
   }
 
   let keys = []
-  if (version === '1') {
+  if (version === '0') {
+    keys = Object.entries(data || {})
+  } else {
     for (const key of data || []) {
       keys.push([key.name, key.secret, key.id])
     }
-  } else {
-    keys = Object.entries(data || {})
   }
 
   return (
@@ -97,7 +97,7 @@ export default function ManageKeys({ user }) {
               <Button
                 href={{
                   pathname: '/new-key',
-                  query: version ? { version: '1' } : null,
+                  query: version ? { version } : null,
                 }}
                 className="flex-none"
                 id="new-key"
@@ -149,7 +149,7 @@ export default function ManageKeys({ user }) {
                             type="hidden"
                             name="name"
                             id={`token-${t[0]}`}
-                            value={version === '1' ? `${t[2]}` : t[0]}
+                            value={version === '0' ? t[0] : `${t[2]}`}
                           />
                           <Button
                             className="bg-nsorange white"
@@ -161,8 +161,7 @@ export default function ManageKeys({ user }) {
                               ui: countly.ui.TOKENS,
                             }}
                           >
-                            {deleting ===
-                            (version === '1' ? `${t[2]}` + '' : t[0])
+                            {deleting === (version === '0' ? t[0] : `${t[2]}`)
                               ? 'Deleting...'
                               : 'Delete'}
                           </Button>

--- a/packages/website/pages/new-file.js
+++ b/packages/website/pages/new-file.js
@@ -54,7 +54,7 @@ export default function NewFile() {
     if (file && file instanceof File) {
       const client = new NFTStorage({
         token: await getToken(),
-        endpoint: new URL(API + (version === '1' ? '/v1/' : '/')),
+        endpoint: new URL(API + (version ? `/v${version}/` : '/')),
       })
       setUploading(true)
       setError('')


### PR DESCRIPTION
This PR moves the `/v1/*` routes to `/` and moves the original routes to `/v0`.

This is the smallest changeset possible to enable this. We should remove the v0 routes in a subsequent PR.

Depends on:

* [ ] https://github.com/ipfs-shipyard/nft.storage/pull/512